### PR TITLE
ドキュメントの生成

### DIFF
--- a/docs_src/conf.py
+++ b/docs_src/conf.py
@@ -1,7 +1,7 @@
-
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 # Configuration file for the Sphinx documentation builder.
 #
@@ -12,30 +12,32 @@ sys.path.insert(0, os.path.abspath('..'))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 
-project = 'DynamoDB SingleTable'
-copyright = '2022, medaka'
-author = 'medaka'
+project = "DynamoDB SingleTable"
+copyright = "2022, medaka"
+author = "medaka"
 
 import ddb_single
-release = ddb_single.__version__
+
+release = ddb_single.__VERSION__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
-
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-#追加
+# 追加
 import sphinx_rtd_theme
+
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 extensions = [
-    'sphinx.ext.autodoc', 'sphinx.ext.napoleon',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
     "myst_parser",
 ]


### PR DESCRIPTION
https://github.com/medaka0213/DynamoDB-SingleTable/issues/11


https://github.com/medaka0213/DynamoDB-SingleTable/actions/runs/5498316601/jobs/10019686505

```Run cp ./readme.md ./docs_src/readme.md
Creating file ./docs_src/ddb_single.rst.
Creating file ./docs_src/modules.rst.
Running Sphinx v6.2.1

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.17/x64/lib/python3.9/site-packages/sphinx/config.py", line 354, in eval_config_file
    exec(code, namespace)  # NoQA: S[10](https://github.com/medaka0213/DynamoDB-SingleTable/actions/runs/5498316601/jobs/10019686505#step:9:11)2
  File "/home/runner/work/DynamoDB-SingleTable/DynamoDB-SingleTable/docs_src/conf.py", line [20](https://github.com/medaka0213/DynamoDB-SingleTable/actions/runs/5498316601/jobs/10019686505#step:9:21), in <module>
    release = ddb_single.__version__
AttributeError: module 'ddb_single' has no attribute '__version__'

Error: Process completed with exit code

```
