### PR TITLE
パッケージがまだインストールされていない場合に備えて例外を無視

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import ddb_single
 import os
 from setuptools import setup
 
@@ -8,11 +7,20 @@ if os.path.exists("readme.md"):
     with open("readme.md", "r") as fp:
         LONG_DESCRIPTION = fp.read()
 
-print("ddb_single version:", ddb_single.__VERSION__)
+# インポートは延期されるので、この時点では'__version__'はまだ未知です
+version = "unknown"
+try:
+    # インポートはここで行われ、'__version__'が利用可能になります
+    import ddb_single
+
+    version = ddb_single.__VERSION__
+except Exception:
+    pass  # パッケージがまだインストールされていない場合に備えて例外を無視します
+
 
 setup(
     name="ddb_single",
-    version=ddb_single.__VERSION__,
+    version=version,
     description=DESCRIPTION,
     url="https://github.com/medaka0213/DynamoDB-SingleTable",
     author="medaka",


### PR DESCRIPTION
https://github.com/medaka0213/DynamoDB-SingleTable/issues/11

```
#0 4.610   × python setup.py egg_info did not run successfully.
#0 4.610   │ exit code: 1
#0 4.610   ╰─> [10 lines of output]
#0 4.610       Traceback (most recent call last):
#0 4.610         File "<string>", line 2, in <module>
#0 4.610         File "<pip-setuptools-caller>", line 34, in <module>
#0 4.610         File "/tmp/pip-install-40fc86fp/ddb-single_4ce4bb2f68b14da58332371115e8e98c/setup.py", line 1, in <module>
#0 4.610           import ddb_single
#0 4.610         File "/tmp/pip-install-40fc86fp/ddb-single_4ce4bb2f68b14da58332371115e8e98c/ddb_single/__init__.py", line 1, in <module>
#0 4.610           from ddb_single.model import BaseModel, DBField  # noqa: F401
#0 4.610         File "/tmp/pip-install-40fc86fp/ddb-single_4ce4bb2f68b14da58332371115e8e98c/ddb_single/model.py", line 2, in <module>
#0 4.610           from boto3.dynamodb.conditions import Key
#0 4.610       ModuleNotFoundError: No module named 'boto3'
#0 4.610       [end of output]
```