### PR TITLE
バージョンがunknownになる

### DIFF
--- a/ddb_single/__init__.py
+++ b/ddb_single/__init__.py
@@ -1,5 +1,8 @@
-from ddb_single.model import BaseModel, DBField  # noqa: F401
-from ddb_single.table import Table  # noqa: F401
-from ddb_single.query import Query  # noqa: F401
+try:
+    from ddb_single.model import BaseModel, DBField  # noqa: F401
+    from ddb_single.table import Table  # noqa: F401
+    from ddb_single.query import Query  # noqa: F401
+except Exception:
+    pass
 
 __VERSION__ = "0.0.0"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import ddb_single
 import os
 from setuptools import setup
 
@@ -7,20 +8,9 @@ if os.path.exists("readme.md"):
     with open("readme.md", "r") as fp:
         LONG_DESCRIPTION = fp.read()
 
-# インポートは延期されるので、この時点では'__version__'はまだ未知です
-version = "unknown"
-try:
-    # インポートはここで行われ、'__version__'が利用可能になります
-    import ddb_single
-
-    version = ddb_single.__VERSION__
-except Exception:
-    pass  # パッケージがまだインストールされていない場合に備えて例外を無視します
-
-
 setup(
     name="ddb_single",
-    version=version,
+    version=ddb_single.__VERSION__,
     description=DESCRIPTION,
     url="https://github.com/medaka0213/DynamoDB-SingleTable",
     author="medaka",


### PR DESCRIPTION
https://github.com/medaka0213/DynamoDB-SingleTable/issues/11
```
#0 4.252   WARNING: Requested ddb_single==0.4.3 from https://files.pythonhosted.org/packages/aa/42/4b7c4caa50f24afdb1eee840669e87a7255335267fe0cb17272f48082074/ddb_single-0.4.3.zip (from -r requirements.txt (line 6)), but installing version unknown
#0 4.253 Discarding https://files.pythonhosted.org/packages/aa/42/4b7c4caa50f24afdb1eee840669e87a7255335267fe0cb17272f48082074/ddb_single-0.4.3.zip (from https://pypi.org/simple/ddb-single/): Requested ddb_single==0.4.3 from https://files.pythonhosted.org/packages/aa/42/4b7c4caa50f24afdb1eee840669e87a7255335267fe0cb17272f48082074/ddb_single-0.4.3.zip (from -r requirements.txt (line 6)) has inconsistent version: expected '0.4.3', but metadata has 'unknown'
#0 4.253 ERROR: Could n
```