### PR TITLE
関連検索 引数が空の場合の処理

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run unittest
         run: |
-          docker run -d -p 8000:8000 amazon/dynamodb-local:2.0.0
+          docker run -d -p 8000:8000 --name dynamodb amazon/dynamodb-local:2.0.0
           coverage run -m unittest discover -s tests/
           coverage report
 

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -193,7 +193,7 @@ class Table:
         try:
             response = self.__table__.query(**kwargs)
         except ClientError as e:
-            logger.error("ClientError: %s", e)
+            logger.error("ClientError", e)
         else:
             if len(response["Items"]):
                 res_data = response["Items"]

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -318,11 +318,17 @@ class Table:
                 FilterExpression=Attr(self.__primary_key__).begins_with(model_name),
                 IndexName=self.__search_index__,
             )
-        else:
+        elif model_name:
             # モデルの指定がある場合
             res = self._query(
                 KeyConditionExpression=KeyConditionExpression
                 & Key(self.__primary_key__).begins_with(model_name),
+                IndexName=self.__range_index_name__,
+            )
+        else:
+            # フィールド・モデルの指定がない場合
+            res = self._query(
+                KeyConditionExpression=KeyConditionExpression,
                 IndexName=self.__range_index_name__,
             )
         pks = [r[self.__primary_key__] for r in res]

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -70,6 +70,12 @@ class TestRelation(unittest.TestCase):
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "test")
 
+        # フィールドから検索
+        res = query.model(blogpost).get_relation()
+        self.assertIsNotNone(res)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["name"], "test")
+
     def test_02_0_get_ref(self):
         res = query.model(self.user).get_reference(model=BlogPost)
         self.assertIsNotNone(res)

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -69,8 +69,7 @@ class TestRelation(unittest.TestCase):
         self.assertIsNotNone(res)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "test")
-
-        # フィールドから検索
+        # 引数なし
         res = query.model(blogpost).get_relation()
         self.assertIsNotNone(res)
         self.assertEqual(len(res), 1)
@@ -83,6 +82,11 @@ class TestRelation(unittest.TestCase):
         self.assertEqual(res[0]["title"], "test")
         # フィールドから検索
         res = query.model(self.user).get_reference(field=BlogPost.author)
+        self.assertIsNotNone(res)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["title"], "test")
+        # 引数なし
+        res = query.model(self.user).get_reference()
         self.assertIsNotNone(res)
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["title"], "test")


### PR DESCRIPTION
- reference の引数が空の場合にエラーになったので修正
- ついでにワークフローでコンテナ名を指定して実行できるようにしとく