### PR TITLE
エラー追加

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Publish github pages
         uses: JamesIves/github-pages-deploy-action@4.1.5
+        if: github.ref == 'refs/heads/master'
         with:
           branch: gh-pages
           folder: ./docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Create GitHub Release
         uses: actions/create-release@v1
+        if: github.ref == 'refs/heads/master'
         with:
           tag_name: v${{ env.VERSION }}
           release_name: Release v${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,6 @@ jobs:
 
       - name: Create GitHub Release
         uses: actions/create-release@v1
-        if: github.ref == 'refs/heads/master'
         with:
           tag_name: v${{ env.VERSION }}
           release_name: Release v${{ env.VERSION }}

--- a/ddb_single/error.py
+++ b/ddb_single/error.py
@@ -1,0 +1,28 @@
+class DDBSingleError(Exception):
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+class ValidationError(DDBSingleError):
+
+    def __str__(self):
+        return f"Falied to validate: {self.message}"
+
+
+class InvalidParameterError(DDBSingleError):
+
+    def __str__(self):
+        return f"Invalid parameter: {self.message}"
+
+
+class NotFoundError(DDBSingleError):
+
+    def __init__(self, message):
+        super().__init__(message)
+
+    def __str__(self):
+        return f"Item not found: {self.message}"

--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -30,6 +30,7 @@ class DBField:
         search_key=False,
         reletion=None,
         reletion_by_unique=True,
+        relation_raise_if_not_found=False,
         ignore_case=False,
         **kwargs,
     ):
@@ -47,7 +48,7 @@ class DBField:
             reletion (BaseModel): The reletion model of the field.
             reference (BaseModel): The reference model of the field.
             reletion_by_unique (bool): Whether the reletion is by unique key.
-            reference_by_unique (bool): Whether the reference is by unique key.
+            relation_raise_if_not_found (bool): Whether to raise an error if the relation is not found.
         """
         self.type = type
         self.default = default
@@ -60,6 +61,7 @@ class DBField:
         self.search_key = search_key or unique_key
         self.relation = reletion
         self.reletion_by_unique = reletion_by_unique
+        self.relation_raise_if_not_found = relation_raise_if_not_found
         self.ignore_case = ignore_case
         self.value = None
 

--- a/ddb_single/query.py
+++ b/ddb_single/query.py
@@ -2,6 +2,7 @@ from typing import Optional, List
 from ddb_single.model import BaseModel, DBField
 from ddb_single.table import Table
 import ddb_single.utils_botos as util_b
+from ddb_single.error import ValidationError
 
 import logging
 
@@ -118,14 +119,14 @@ class Query:
         Create a new item.
         Args:
             batch: BatchWriteItem
-            raise_if_exists (bool): Throw exception if item already exists
+            raise_if_exists (bool): Throw ValidationError if item already exists
         """
         old_item = self.get_by_unique(
             self.__model__.data[self.__model__.__unique_keys__[0]]
         )
         if old_item:
             if raise_if_exists:
-                raise Exception("Item Already exists")
+                raise ValidationError("Item Already exists")
             else:
                 self._update(old_item, new_item={}, batch=batch)
         else:
@@ -200,7 +201,7 @@ class Query:
             self.delete_by_pk(target[self.__model__.__primary_key__], batch=batch)
         else:
             # 両方とも無ければエラー
-            raise Exception("Primary key or Unique key is required.")
+            raise ValidationError("Primary key or Unique key is required.")
 
     def delete_by_unique(self, value, batch=None):
         """

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -495,6 +495,7 @@ class Table:
 
     # バッチ処理
     def batch_delete_items(self, items, batch=None):
+        logger.debug(f"batch_delete_items: {items}")
         if batch:
             for item in items:
                 self.detele_item(item, batch)

--- a/ddb_single/utils_botos.py
+++ b/ddb_single/utils_botos.py
@@ -1,5 +1,6 @@
 from boto3.dynamodb.conditions import Key, Attr
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from ddb_single.error import InvalidParameterError
 
 # クエリ設定のENUM
 from enum import Enum
@@ -64,7 +65,7 @@ def range_ex(name, value, mode):
     elif mode == QueryType.BEGINS:
         result = Key(name).begins_with(value)
     else:
-        raise Exception(f"mode={mode} is not defined.")
+        raise InvalidParameterError(f"mode={mode} is not defined.")
 
     return result
 
@@ -96,7 +97,7 @@ def attr_ex(name, value, mode):
     elif mode == QueryType.N_EX:
         result = Attr(name).not_exists()
     else:
-        raise Exception(f"mode={mode} is not defined.")
+        raise InvalidParameterError(f"mode={mode} is not defined.")
     return result
 
 
@@ -126,7 +127,7 @@ def attr_method(name, value, mode):
     elif mode == QueryType.N_EX:
         result = lambda x: name not in x  # noqa: E731
     else:
-        raise Exception(f"mode={mode} is not defined.")
+        raise InvalidParameterError(f"mode={mode} is not defined.")
     return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ homepage = "https://medaka0213.github.io/DynamoDB-SingleTable/"
 repository = "https://github.com/medaka0213/DynamoDB-SingleTable"
 keywords = ["aws", "dynamodb", "serverless"]
 packages = [{ include = "ddb_single" }]
+readme = "readme.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
- 自作のエラーを追加
- 見つからない場合のエラー追加: 関連Issue https://github.com/medaka0213/DynamoDB-SingleTable/issues/29
  - DBField クラスにパラメータ追加: `relation_raise_if_not_found`
   Trueの場合、存在しないアイテムに関連付けしようとするとエラーにする