### PR TITLE
fix: 検索系の制限値は一回だけ最後に反映する

### DIFF
--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -387,49 +387,54 @@ class Table:
                     res &= set(_res)
                 else:
                     res = set(_res)
+
+            # filter_ex があればフィルタ
+            res = self.batch_get_from_pks(list(res))
+            if staged_ex and filter_ex:
+                logger.debug("Both staged_ex and filter_ex found. Filtering items...")
+                res = self.filter(res, filter_ex)
+            if limit is not None:
+                res = list(res)[:limit]
+            if pk_only:
+                return [r[self.__primary_key__] for r in res]
+            return res
+
+        # シンプルにクエリ検索
+        logger.debug(f"simple_ex: {simple_ex}")
+        KeyConditionExpression = Key(self.__secondary_key__).eq(self.sk(model_name))
+        for ex in simple_ex:
+            KeyConditionExpression &= ex["KeyConditionExpression"]
+        if filter_ex:
+            # フィルタがあれば追加
+            FilterExpression = filter_ex[0]["FilterExpression"]
+            for ex in filter_ex[1:]:
+                FilterExpression &= ex["FilterExpression"]
+            _res = (
+                self._query(
+                    KeyConditionExpression=KeyConditionExpression,
+                    FilterExpression=FilterExpression,
+                    IndexName=self.__range_index_name__,
+                    ProjectionExpression=self.__primary_key__,
+                )
+                or []
+            )
         else:
-            # シンプルにクエリ検索
-            logger.debug(f"simple_ex: {simple_ex}")
-            KeyConditionExpression = Key(self.__secondary_key__).eq(self.sk(model_name))
-            for ex in simple_ex:
-                KeyConditionExpression &= ex["KeyConditionExpression"]
-            if filter_ex:
-                # フィルタがあれば追加
-                FilterExpression = filter_ex[0]["FilterExpression"]
-                for ex in filter_ex[1:]:
-                    FilterExpression &= ex["FilterExpression"]
-                _res = (
-                    self._query(
-                        KeyConditionExpression=KeyConditionExpression,
-                        FilterExpression=FilterExpression,
-                        IndexName=self.__range_index_name__,
-                        ProjectionExpression=self.__primary_key__,
-                    )
-                    or []
+            # フィルタがなければ全件検索
+            logger.debug("FilterExpression not found")
+            _res = (
+                self._query(
+                    KeyConditionExpression=KeyConditionExpression,
+                    IndexName=self.__range_index_name__,
+                    ProjectionExpression=self.__primary_key__,
                 )
-            else:
-                # フィルタがなければ全件検索
-                logger.debug("FilterExpression not found")
-                _res = (
-                    self._query(
-                        KeyConditionExpression=KeyConditionExpression,
-                        IndexName=self.__range_index_name__,
-                        ProjectionExpression=self.__primary_key__,
-                    )
-                    or []
-                )
-            res = set([r[self.__primary_key__] for r in _res])
+                or []
+            )
+        res = set([r[self.__primary_key__] for r in _res])
         if limit is not None:
             res = list(res)[:limit]
         if pk_only:
             return list(res)
-
-        res = self.batch_get_from_pks(list(res))
-        if staged_ex and filter_ex:
-            #  filter_ex があればフィルタ
-            logger.debug("Both staged_ex and filter_ex found. Filtering items...")
-            res = self.filter(res, filter_ex)
-        return res
+        return self.batch_get_from_pks(list(res))
 
     # --- 更新関連 ---
     # バッチライター

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -1,3 +1,5 @@
+from functools import reduce
+import operator
 import boto3
 from boto3.dynamodb.conditions import Key, Attr
 from botocore.exceptions import ClientError
@@ -413,10 +415,7 @@ class Table:
         for ex in simple_ex:
             KeyConditionExpression &= ex["KeyConditionExpression"]
         if filter_ex:
-            # フィルタがあれば追加
-            FilterExpression = filter_ex[0]["FilterExpression"]
-            for ex in filter_ex[1:]:
-                FilterExpression &= ex["FilterExpression"]
+            FilterExpression = reduce(operator.and_, (ex["FilterExpression"] for ex in filter_ex))
             _res = (
                 self._query(
                     KeyConditionExpression=KeyConditionExpression,

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -357,8 +357,16 @@ class Table:
                     break
         return res
 
-    # 検索
     def search(self, model_name, *searchEx, pk_only=False, limit=None):
+        """Search items
+        Args:
+            model_name (str): model name
+            searchEx (list[dict]): search expression
+            pk_only (bool, optional): return only primary key. Defaults to False.
+            limit (int, optional): limit. Defaults to None.
+        Returns:
+            list[dict]: items
+        """
         simple_ex = [
             s for s in searchEx if s["FilterStatus"] == util_b.FilterStatus.SEATCH
         ]

--- a/tests/test_search_table.py
+++ b/tests/test_search_table.py
@@ -11,7 +11,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 table = Table(
-    table_name="search_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    table_name="table_search_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
     endpoint_url="http://localhost:8000",
     region_name="us-west-2",
     aws_access_key_id="fakeMyKeyId",

--- a/tests/test_search_table.py
+++ b/tests/test_search_table.py
@@ -1,0 +1,170 @@
+import unittest
+
+from ddb_single.table import FieldType, Table, Key, Attr
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+import ddb_single.utils_botos as util_b
+
+import datetime
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+table = Table(
+    table_name="search_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    endpoint_url="http://localhost:8000",
+    region_name="us-west-2",
+    aws_access_key_id="fakeMyKeyId",
+    aws_secret_access_key="fakeSecretAccessKey",
+)
+table.init()
+
+
+class User(BaseModel):
+    __table__ = table
+    __model_name__ = "user"
+    name = DBField(unique_key=True)
+    email = DBField(search_key=True)
+    age = DBField(type=FieldType.NUMBER, search_key=True)
+    description = DBField()
+
+
+class UserNotFound(BaseModel):
+    __table__ = table
+    __model_name__ = "userNotFound"
+    name = DBField(unique_key=True)
+
+
+query = Query(table)
+
+print("table_name:", table.__table_name__)
+
+
+class TestSearchTable(unittest.TestCase):
+    def setUp(self):
+        for i in range(30):
+            test = User(
+                name=f"test{str(i).zfill(2)}",
+                age=i,
+                description=f"test description {'odd' if i % 2 == 0 else 'even'}_{i}",)
+            query.model(test).create()
+        test = UserNotFound(name="testNotFound")
+        query.model(test).create()
+
+    def test_search_staged_single(self):
+        """STAGED"""
+        searchEx = [{
+            "FilterStatus": util_b.FilterStatus.STAGED,
+            "IndexName": table.__search_index__,
+            "KeyConditionExpression": Key("sk").eq("search_user_name") & Key("data").eq("test01"),
+        }]
+        res = table.search("user", *searchEx)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["name"], "test01")
+
+        # pk_only
+        res = table.search("user", *searchEx, pk_only=True)
+        self.assertEqual(len(res), 1)
+        self.assertIsInstance(res[0], str)
+
+    def test_search_staged_double(self):
+        """STAGED複数"""
+        searchEx = [{
+            "FilterStatus": util_b.FilterStatus.STAGED,
+            "IndexName": table.__search_index__,
+            "KeyConditionExpression": Key("sk").eq("search_user_name") & Key("data").begins_with("test1"),
+        }, {
+            "FilterStatus": util_b.FilterStatus.STAGED,
+            "IndexName": table.__search_num_index__,
+            "KeyConditionExpression": Key("sk").eq("search_user_age") & Key("data-n").lte(15),
+        }]
+        res = table.search("user", *searchEx)
+        self.assertEqual(len(res), 6)
+        for r in res:
+            self.assertLessEqual(r["age"], 15)
+            self.assertTrue(r["name"].startswith("test1"))
+
+        # pk_only
+        res = table.search("user", *searchEx, pk_only=True)
+        self.assertEqual(len(res), 6)
+        for r in res:
+            self.assertIsInstance(r, str)
+
+    def test_search_staged_double_limit(self):
+        """STAGED複数 + limit"""
+        searchEx = [{
+            "FilterStatus": util_b.FilterStatus.STAGED,
+            "IndexName": table.__search_index__,
+            "KeyConditionExpression": Key("sk").eq("search_user_name") & Key("data").begins_with("test1"),
+        }, {
+            "FilterStatus": util_b.FilterStatus.STAGED,
+            "IndexName": table.__search_num_index__,
+            "KeyConditionExpression": Key("sk").eq("search_user_age") & Key("data-n").lte(15),
+        }]
+        res = table.search("user", *searchEx, limit=3)
+        self.assertEqual(len(res), 3)
+        for r in res:
+            self.assertLessEqual(r["age"], 15)
+            self.assertTrue(r["name"].startswith("test1"))
+
+        # pk_only
+        res = table.search("user", *searchEx, pk_only=True, limit=3)
+        self.assertEqual(len(res), 3)
+        for r in res:
+            self.assertIsInstance(r, str)
+
+    def test_search_staged_filter(self):
+        """STAGED + フィルタ"""
+        searchEx = [{
+            "FilterStatus": util_b.FilterStatus.STAGED,
+            "IndexName": table.__search_index__,
+            "KeyConditionExpression": Key("sk").eq("search_user_name") & Key("data").begins_with("test2"),
+        }, {
+            "FilterStatus": util_b.FilterStatus.FILTER,
+            "FilterMethod": util_b.attr_method("description", "odd", util_b.QueryType.CONTAINS),
+            "FilterExpression": Attr("description").contains("odd"),
+        }]
+        res = table.search("user", *searchEx)
+        self.assertEqual(len(res), 5)
+        for r in res:
+            self.assertIn("odd", r["description"])
+            self.assertTrue(r["name"].startswith("test2"))
+
+        # pk_only
+        res = table.search("user", *searchEx, pk_only=True)
+        self.assertEqual(len(res), 5)
+        for r in res:
+            self.assertIsInstance(r, str)
+
+    def test_search_filter(self):
+        """フィルタ"""
+        searchEx = [{
+            "FilterStatus": util_b.FilterStatus.FILTER,
+            "FilterMethod": util_b.attr_method("description", "odd", util_b.QueryType.CONTAINS),
+            "FilterExpression": Attr("description").contains("odd"),
+        }]
+        res = table.search("user", *searchEx)
+        self.assertEqual(len(res), 15)
+        for r in res:
+            self.assertIn("odd", r["description"])
+
+        # pk_only
+        res = table.search("user", *searchEx, pk_only=True)
+        self.assertEqual(len(res), 15)
+        for r in res:
+            self.assertIsInstance(r, str)
+
+    def test_search_all(self):
+        """全件検索"""
+        res = table.search("user")
+        self.assertEqual(len(res), 30)
+
+        # pk_only
+        res = table.search("user", pk_only=True)
+        self.assertEqual(len(res), 30)
+        for r in res:
+            self.assertIsInstance(r, str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- クエリとフィルタ処理を強化した検索機能の改善。
	- より良いパフォーマンスのために、結果のフォーマットと制限を簡素化。
	- 検索結果の返却プロセスを簡素化。

- **バグ修正**
	- フィルタリングと結果取得に影響を与えていた以前の検索ロジックの問題を解決。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->