### PR TITLE
Bump version to 0.4.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [tool.poetry]
 authors = ["medaka0213"]
 name = "ddb_single"
-version = "0.4.15"
+version = "0.4.16"
 description = "Python DynamoDB interface, specialized in single-table design."
 license = "MIT"
 homepage = "https://medaka0213.github.io/DynamoDB-SingleTable/"


### PR DESCRIPTION
Bump version to 0.4.16
### [0.4.16](https://github.com/medaka0213/DynamoDB-SingleTable/compare/v0.4.15...v0.4.16) (2024-09-21)


### Bug Fixes

* リリースのワークフロー戻す ([6dbe542](https://github.com/medaka0213/DynamoDB-SingleTable/commit/6dbe5425686c48d21834d6350fcfaca4e1bf8ae3))
* リリース用: v0.4.15に手動更新 ([0e3fae8](https://github.com/medaka0213/DynamoDB-SingleTable/commit/0e3fae8aab28b5e6c3bc2d6484085c037e6513b0))