### PR TITLE
fix: 検索用のパラメータにもバリデーション追加

### DIFF
--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -227,6 +227,10 @@ class DBField:
         Returns:
             dict: The key expression.
         """
+        if mode == util_b.QueryType.BETWEEN:
+            value = list(map(self.validate, value))
+        else:
+            value = self.validate(value)
         if self.ignore_case and isinstance(value, str):
             value = value.lower()
         if self.secondary_key:

--- a/ddb_single/utils_botos.py
+++ b/ddb_single/utils_botos.py
@@ -51,83 +51,62 @@ def is_key(mode):
 
 
 def range_ex(name, value, mode):
-    if mode == QueryType.EQ:
-        result = Key(name).eq(value)
-    elif mode == QueryType.BETWEEN:
-        result = Key(name).between(min(*value), max(*value))
-    elif mode == QueryType.LT:
-        result = Key(name).lt(value)
-    elif mode == QueryType.LT_E:
-        result = Key(name).lte(value)
-    elif mode == QueryType.GT:
-        result = Key(name).gt(value)
-    elif mode == QueryType.GT_E:
-        result = Key(name).gte(value)
-    elif mode == QueryType.BEGINS:
-        result = Key(name).begins_with(value)
-    else:
+    func_mapping = {
+        QueryType.EQ: lambda n, v: Key(n).eq(v),
+        QueryType.BETWEEN: lambda n, v: Key(n).between(min(*v), max(*v)),
+        QueryType.LT: lambda n, v: Key(n).lt(v),
+        QueryType.LT_E: lambda n, v: Key(n).lte(v),
+        QueryType.GT: lambda n, v: Key(n).gt(v),
+        QueryType.GT_E: lambda n, v: Key(n).gte(v),
+        QueryType.BEGINS: lambda n, v: Key(n).begins_with(v),
+    }
+    try:
+        result = func_mapping[mode](name, value)
+    except KeyError:
         raise InvalidParameterError(f"mode={mode} is not defined.")
-
     return result
 
 
 # その他の変数の検索フィルター
 def attr_ex(name, value, mode):
-    if mode == QueryType.EQ:
-        result = Attr(name).eq(value)
-    elif mode == QueryType.BETWEEN:
-        result = Attr(name).between(min(*value), max(*value))
-    elif mode == QueryType.LT:
-        result = Attr(name).lt(value)
-    elif mode == QueryType.LT_E:
-        result = Attr(name).lte(value)
-    elif mode == QueryType.GT:
-        result = Attr(name).gt(value)
-    elif mode == QueryType.GT_E:
-        result = Attr(name).gte(value)
-    elif mode == QueryType.BEGINS:
-        result = Attr(name).begins_with(value)
-    elif mode == QueryType.CONTAINS:
-        result = Attr(name).contains(value)
-    elif mode == QueryType.IN:
-        result = Attr(name).in_(value)
-    elif mode == QueryType.N_EQ:
-        result = Attr(name).ne(value)
-    elif mode == QueryType.EX:
-        result = Attr(name).exists()
-    elif mode == QueryType.N_EX:
-        result = Attr(name).not_exists()
-    else:
+    func_mapping = {
+        QueryType.EQ: lambda n, v: Attr(n).eq(v),
+        QueryType.BETWEEN: lambda n, v: Attr(n).between(min(*v), max(*v)),
+        QueryType.LT: lambda n, v: Attr(n).lt(v),
+        QueryType.LT_E: lambda n, v: Attr(n).lte(v),
+        QueryType.GT: lambda n, v: Attr(n).gt(v),
+        QueryType.GT_E: lambda n, v: Attr(n).gte(v),
+        QueryType.BEGINS: lambda n, v: Attr(n).begins_with(v),
+        QueryType.CONTAINS: lambda n, v: Attr(n).contains(v),
+        QueryType.IN: lambda n, v: Attr(n).is_in(v),
+        QueryType.N_EQ: lambda n, v: Attr(n).ne(v),
+        QueryType.EX: lambda n, v: Attr(n).exists(),
+        QueryType.N_EX: lambda n, v: Attr(n).not_exists(),
+    }
+    try:
+        result = func_mapping[mode](name, value)
+    except KeyError:
         raise InvalidParameterError(f"mode={mode} is not defined.")
     return result
 
 
 def attr_method(name, value, mode):
-    if mode == QueryType.EQ:
-        def result(x): return x.get(name) == value
-    elif mode == QueryType.BETWEEN:
-        def result(x): return min(*value) <= x.get(name) <= max(*value)
-    elif mode == QueryType.LT:
-        def result(x): return x.get(name) < value
-    elif mode == QueryType.LT_E:
-        def result(x): return x.get(name) <= value
-    elif mode == QueryType.GT:
-        def result(x): return x.get(name) > value
-    elif mode == QueryType.GT_E:
-        def result(x): return x.get(name) >= value
-    elif mode == QueryType.BEGINS:
-        def result(x): return x.get(name).startswith(value)
-    elif mode == QueryType.CONTAINS:
-        def result(x): return value in x.get(name)
-    elif mode == QueryType.IN:
-        def result(x): return x.get(name) in value
-    elif mode == QueryType.N_EQ:
-        def result(x): return x.get(name) != value
-    elif mode == QueryType.EX:
-        def result(x): return name in x
-    elif mode == QueryType.N_EX:
-        def result(x): return name not in x
-    else:
+    func_mapping = {
+        QueryType.EQ: lambda x: x.get(name) == value,
+        QueryType.BETWEEN: lambda x: min(*value) <= x.get(name) <= max(*value),
+        QueryType.LT: lambda x: x.get(name) < value,
+        QueryType.LT_E: lambda x: x.get(name) <= value,
+        QueryType.GT: lambda x: x.get(name) > value,
+        QueryType.GT_E: lambda x: x.get(name) >= value,
+        QueryType.BEGINS: lambda x: x.get(name).startswith(value),
+        QueryType.CONTAINS: lambda x: value in x.get(name),
+        QueryType.IN: lambda x: x.get(name) in value,
+        QueryType.N_EQ: lambda x: x.get(name) != value,
+        QueryType.EX: lambda x: name in x,
+        QueryType.N_EX: lambda x: name not in x,
+    }
+    result = func_mapping.get(mode)
+    if result is None:
         raise InvalidParameterError(f"mode={mode} is not defined.")
     return result
 

--- a/ddb_single/utils_botos.py
+++ b/ddb_single/utils_botos.py
@@ -86,7 +86,8 @@ def attr_ex(name, value, mode):
     }
     try:
         result = func_mapping[mode](name, value)
-    except KeyError:
+    except KeyError as err:
+        raise InvalidParameterError(f"mode={mode} is not defined.") from err
         raise InvalidParameterError(f"mode={mode} is not defined.")
     return result
 

--- a/ddb_single/utils_botos.py
+++ b/ddb_single/utils_botos.py
@@ -62,7 +62,8 @@ def range_ex(name, value, mode):
     }
     try:
         result = func_mapping[mode](name, value)
-    except KeyError:
+    except KeyError as err:
+        raise InvalidParameterError(f"mode={mode} is not defined.") from err
         raise InvalidParameterError(f"mode={mode} is not defined.")
     return result
 

--- a/ddb_single/utils_botos.py
+++ b/ddb_single/utils_botos.py
@@ -1,3 +1,4 @@
+# ddb_single/utils_botos.py
 from boto3.dynamodb.conditions import Key, Attr
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from ddb_single.error import InvalidParameterError
@@ -103,29 +104,29 @@ def attr_ex(name, value, mode):
 
 def attr_method(name, value, mode):
     if mode == QueryType.EQ:
-        result = lambda x: x.get(name) == value  # noqa: E731
+        def result(x): return x.get(name) == value
     elif mode == QueryType.BETWEEN:
-        result = lambda x: min(*value) <= x.get(name) <= max(*value)  # noqa: E731
+        def result(x): return min(*value) <= x.get(name) <= max(*value)
     elif mode == QueryType.LT:
-        result = lambda x: x.get(name) < value  # noqa: E731
+        def result(x): return x.get(name) < value
     elif mode == QueryType.LT_E:
-        result = lambda x: x.get(name) <= value  # noqa: E731
+        def result(x): return x.get(name) <= value
     elif mode == QueryType.GT:
-        result = lambda x: x.get(name) > value  # noqa: E731
+        def result(x): return x.get(name) > value
     elif mode == QueryType.GT_E:
-        result = lambda x: x.get(name) >= value  # noqa: E731
+        def result(x): return x.get(name) >= value
     elif mode == QueryType.BEGINS:
-        result = lambda x: x.get(name).startswith(value)  # noqa: E731
+        def result(x): return x.get(name).startswith(value)
     elif mode == QueryType.CONTAINS:
-        result = lambda x: value in x.get(name)  # noqa: E731
+        def result(x): return value in x.get(name)
     elif mode == QueryType.IN:
-        result = lambda x: x.get(name) in value  # noqa: E731
+        def result(x): return x.get(name) in value
     elif mode == QueryType.N_EQ:
-        result = lambda x: x.get(name) != value  # noqa: E731
+        def result(x): return x.get(name) != value
     elif mode == QueryType.EX:
-        result = lambda x: name in x  # noqa: E731
+        def result(x): return name in x
     elif mode == QueryType.N_EX:
-        result = lambda x: name not in x  # noqa: E731
+        def result(x): return name not in x
     else:
         raise InvalidParameterError(f"mode={mode} is not defined.")
     return result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch
 from boto3.dynamodb.conditions import Key, Attr
 from decimal import Decimal
 from ddb_single.utils_botos import range_ex, attr_ex, attr_method, is_same_json, json_import, json_export, QueryType

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch
+from boto3.dynamodb.conditions import Key, Attr
 from decimal import Decimal
 from ddb_single.utils_botos import range_ex, attr_ex, attr_method, is_same_json, json_import, json_export, QueryType
 from ddb_single.error import InvalidParameterError
@@ -7,31 +8,27 @@ from ddb_single.error import InvalidParameterError
 
 class TestUtilsBotos(unittest.TestCase):
 
-    @patch('ddb_single.utils_botos.Key')
-    def test_range_ex(self, mock_key):
+    def test_range_ex(self):
         # Equal mode
-        range_ex('test', 'value', QueryType.EQ)
-        mock_key.assert_called_with('test')
-        mock_key.return_value.eq.assert_called_with('value')
+        res = range_ex('test', 'value', QueryType.EQ)
+        self.assertEqual(res, Key('test').eq('value'))
 
         # Between mode
-        range_ex('test', [1, 10], QueryType.BETWEEN)
-        mock_key.return_value.between.assert_called_with(1, 10)
+        res = range_ex('test', [1, 10], QueryType.BETWEEN)
+        self.assertEqual(res, Key('test').between(1, 10))
 
         # Invalid mode
         with self.assertRaises(InvalidParameterError):
             range_ex('test', 'value', 'INVALID_MODE')
 
-    @patch('ddb_single.utils_botos.Attr')
-    def test_attr_ex(self, mock_attr):
+    def test_attr_ex(self):
         # Contains mode
-        attr_ex('test', 'value', QueryType.CONTAINS)
-        mock_attr.assert_called_with('test')
-        mock_attr.return_value.contains.assert_called_with('value')
+        res = attr_ex('test', 'value', QueryType.CONTAINS)
+        self.assertEqual(res, Attr('test').contains('value'))
 
         # In mode
-        attr_ex('test', ['value1', 'value2'], QueryType.IN)
-        mock_attr.return_value.in_.assert_called_with(['value1', 'value2'])
+        res = attr_ex('test', ['value1', 'value2'], QueryType.IN)
+        self.assertEqual(res, Attr('test').is_in(['value1', 'value2']))
 
         # Invalid mode
         with self.assertRaises(InvalidParameterError):
@@ -47,6 +44,10 @@ class TestUtilsBotos(unittest.TestCase):
         method = attr_method('test', [1, 10], QueryType.BETWEEN)
         self.assertTrue(method({'test': 5}))
         self.assertFalse(method({'test': 11}))
+
+        # Invalid mode
+        with self.assertRaises(InvalidParameterError):
+            attr_method('test', 'value', 'INVALID_MODE')
 
     def test_is_same_json(self):
         # Same dictionaries

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch
+from decimal import Decimal
+from ddb_single.utils_botos import range_ex, attr_ex, attr_method, is_same_json, json_import, json_export, QueryType
+from ddb_single.error import InvalidParameterError
+
+
+class TestUtilsBotos(unittest.TestCase):
+
+    @patch('ddb_single.utils_botos.Key')
+    def test_range_ex(self, mock_key):
+        # Equal mode
+        range_ex('test', 'value', QueryType.EQ)
+        mock_key.assert_called_with('test')
+        mock_key.return_value.eq.assert_called_with('value')
+
+        # Between mode
+        range_ex('test', [1, 10], QueryType.BETWEEN)
+        mock_key.return_value.between.assert_called_with(1, 10)
+
+        # Invalid mode
+        with self.assertRaises(InvalidParameterError):
+            range_ex('test', 'value', 'INVALID_MODE')
+
+    @patch('ddb_single.utils_botos.Attr')
+    def test_attr_ex(self, mock_attr):
+        # Contains mode
+        attr_ex('test', 'value', QueryType.CONTAINS)
+        mock_attr.assert_called_with('test')
+        mock_attr.return_value.contains.assert_called_with('value')
+
+        # In mode
+        attr_ex('test', ['value1', 'value2'], QueryType.IN)
+        mock_attr.return_value.in_.assert_called_with(['value1', 'value2'])
+
+        # Invalid mode
+        with self.assertRaises(InvalidParameterError):
+            attr_ex('test', 'value', 'INVALID_MODE')
+
+    def test_attr_method(self):
+        # Equal mode
+        method = attr_method('test', 'value', QueryType.EQ)
+        self.assertTrue(method({'test': 'value'}))
+        self.assertFalse(method({'test': 'wrong_value'}))
+
+        # Between mode
+        method = attr_method('test', [1, 10], QueryType.BETWEEN)
+        self.assertTrue(method({'test': 5}))
+        self.assertFalse(method({'test': 11}))
+
+    def test_is_same_json(self):
+        # Same dictionaries
+        data_1 = {'key1': 'value1', 'key2': 'value2'}
+        data_2 = {'key1': 'value1', 'key2': 'value2'}
+        self.assertTrue(is_same_json(data_1, data_2))
+
+        # Different dictionaries
+        data_3 = {'key1': 'value1', 'key2': 'different_value'}
+        self.assertFalse(is_same_json(data_1, data_3))
+
+    def test_json_import(self):
+        data = {
+            'key1': 1.23,
+            'key2': [2.34, 3.45],
+            'key3': {'key4': 4.56}
+        }
+        expected = {
+            'key1': Decimal('1.23'),
+            'key2': [Decimal('2.34'), Decimal('3.45')],
+            'key3': {'key4': Decimal('4.56')}
+        }
+        self.assertEqual(json_import(data), expected)
+
+    def test_json_export(self):
+        data = {
+            'key1': Decimal('1.23'),
+            'key2': [Decimal('2.34'), Decimal('3.45')],
+            'key3': {'key4': Decimal('4.56')}
+        }
+        expected = {
+            'key1': 1.23,
+            'key2': [2.34, 3.45],
+            'key3': {'key4': 4.56}
+        }
+        self.assertEqual(json_export(data), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
文字列のパラメータに数字が出てきた場合のためにバリデーションを追加する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 検索機能の強化：ユーザー名や年齢に基づく検索機能が改善され、数値文字列での検索が可能に。
  
- **バグ修正**
  - 検索機能のテストケースを追加し、異なる条件下での動作を確認。

- **ドキュメント**
  - ユーティリティ関数に対する新しいユニットテストが追加され、DynamoDB操作の正確性を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->