### PR TITLE
fix: ヴァリデーション失敗時のログ

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -47,11 +47,23 @@ jobs:
           poetry run sphinx-apidoc -f -o ./docs_src ./ddb_single
           poetry run sphinx-build ./docs_src ./docs
 
-      - name: Publish github pages
-        uses: JamesIves/github-pages-deploy-action@v4.7.3
-        if: github.ref == 'refs/heads/master'
+      - name: Upload static files as artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          branch: gh-pages
-          folder: ./docs
-          clean: true
-          commit-message: Deploy as of ${{ github.sha }}
+          path: ./docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: lint_and_test
+    permissions:
+      contents: write
+      id-token: write
+      pages: write
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -148,7 +148,9 @@ class DBField:
     def _validate_value(self, value):
         if self.is_list():
             if not isinstance(value, list):
-                raise ValidationError(f"{self.name} must be a list")
+                raise ValidationError(
+                    f"{self.name} must be a list: {self.type} != {type(value)}"
+                )
             try:
                 if self.type == FieldType.LIST:
                     return value
@@ -161,11 +163,15 @@ class DBField:
                 return value
             except Exception as e:
                 logger.info("Failed to validate", exc_info=e)
-                raise ValidationError(f"{self.name} must be a valid list")
+                raise ValidationError(
+                    f"{self.name} must be a valid list: {self.type} != {type(value)}"
+                )
         else:
             try:
                 if isinstance(value, list):
-                    raise ValidationError(f"{self.name} must not be a list")
+                    raise ValidationError(
+                        f"{self.name} must not be a list: {self.type} != {type(value)}"
+                    )
                 if self.type == FieldType.STRING:
                     return str(value)
                 elif self.type == FieldType.NUMBER:
@@ -177,7 +183,9 @@ class DBField:
                 return value
             except Exception as e:
                 logger.info("Failed to validate", exc_info=e)
-                raise ValidationError(f"Value {self.name} must be a valid value")
+                raise ValidationError(
+                    f"Value {self.name} must be a valid value, {self.type} != {type(value)}"
+                )
 
     def search_key_factory(self):
         """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - GitHub Pagesへのデプロイ手順が2段階に分割され、デプロイ処理の権限と実行条件が明確になりました。

- **改善**
  - バリデーションエラー発生時のメッセージに、期待される型や実際の型など詳細な情報が追加され、エラー内容が分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->