### PR TITLE
Bump version to 0.4.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [tool.poetry]
 authors = ["medaka0213"]
 name = "ddb_single"
-version = "0.4.18"
+version = "0.4.19"
 description = "Python DynamoDB interface, specialized in single-table design."
 license = "MIT"
 homepage = "https://medaka0213.github.io/DynamoDB-SingleTable/"


### PR DESCRIPTION
Bump version to 0.4.19
### [0.4.19](https://github.com/medaka0213/DynamoDB-SingleTable/compare/v0.4.18...v0.4.19) (2025-04-19)


### Bug Fixes

* ヴァリデーション失敗時のログ ([#58](https://github.com/medaka0213/DynamoDB-SingleTable/issues/58)) ([b18e5bf](https://github.com/medaka0213/DynamoDB-SingleTable/commit/b18e5bf042d7fd3011dc3e535b407b70cd288b1b))