### PR TITLE
fix: validateで値がつかいまわされている不具合修正

### DIFF
--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -103,18 +103,26 @@ class DBField:
 
     def validate(self, value=None, skip=False):
         """
+        値をバリデーションして、フィールドの値を設定
         Args:
             value: The value to be validated. If not provided, the value of the field will be used.
         Returns:
             The validated value.
         """
+        # 先に必ずクリア
+        self.value = None
         self.__setup__ = True
+
         if value is not None:
             self.value = value
-        elif self.default:
+        elif self.default is not None:
             self.value = self.default
         elif self.default_factory:
             self.value = self.default_factory(self.__model_cls__)
+        else:
+            # どれもなければ None を明示
+            self.value = None
+
         if not skip:
             if value is None:
                 if not self.nullable:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -219,5 +219,28 @@ class TestCRUD(unittest.TestCase):
         mock_delete_by_unique.assert_called_once_with("test3", batch=None)
 
 
+class SimpleModel(BaseModel):
+    __table__ = table
+    __model_name__ = "simple"
+    # nullable=True, default=None, default_factory=None の場合に
+    # 前回の値が残っていないことを確認
+    name = DBField(unique_key=True, nullable=False)
+    optional_field = DBField(nullable=True)
+
+
+class TestValueReuse(unittest.TestCase):
+    def test_optional_field_not_reused_across_instances(self):
+        # 1回目は値を渡す
+        first = SimpleModel(name="test-1", optional_field="first_value")
+        self.assertEqual(first.data["optional_field"], "first_value")
+
+        # 2回目は値を渡さない → None を期待
+        second = SimpleModel(name="test-1")
+        self.assertIsNone(
+            second.data["optional_field"],
+            "optional_field が前回の 'first_value' を使い回しています",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - オプションフィールドの値が異なるインスタンス間で再利用されないよう修正されました。これにより、前のインスタンスの値が新しいインスタンスに引き継がれる問題が解消されます。

- **テスト**
  - フィールド値の再利用が発生しないことを確認する新しいテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->