### PR TITLE
fix: 削除対象が存在しない場合にスキップ

### DIFF
--- a/ddb_single/query.py
+++ b/ddb_single/query.py
@@ -246,6 +246,9 @@ class Query:
             batch: BatchWriteItem
         """
         target = self.get_by_unique(value)
+        if target is None:
+            # 存在しない場合はスキップ
+            logger.info(f"Item not found: {value} ... skip")
         pk = target.get(self.__model__.__primary_key__)
         self.delete_by_pk(pk, batch=batch)
 

--- a/ddb_single/query.py
+++ b/ddb_single/query.py
@@ -246,9 +246,10 @@ class Query:
             batch: BatchWriteItem
         """
         target = self.get_by_unique(value)
-        if target is None:
+        if not target:
             # 存在しない場合はスキップ
             logger.info(f"Item not found: {value} ... skip")
+            return
         pk = target.get(self.__model__.__primary_key__)
         self.delete_by_pk(pk, batch=batch)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -186,6 +186,9 @@ class TestCRUD(unittest.TestCase):
         res = query.model(User).search(User.name.eq("test"))
         self.assertEqual(len(res), 0)
 
+        # 存在しないデータを削除しようとした場合 (エラーにならない)
+        query.model(User).delete_by_unique("test")
+
     def test_04_02_delete_by_pk(self):
         # 対象データが存在することを確認
         res = query.model(User).search(User.name.eq("test2"))
@@ -195,6 +198,9 @@ class TestCRUD(unittest.TestCase):
         # 効果確認
         res = query.model(User).search(User.name.eq("test2"))
         self.assertEqual(len(res), 0)
+
+        # 存在しないデータを削除しようとした場合 (エラーにならない)
+        query.model(User).delete_by_pk("user_test2")
 
     @patch("ddb_single.query.Query.delete_by_pk")
     def test_04_03_delete_by_pk_2(self, mock_delete_by_pk: MagicMock):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 存在しないデータの削除を試みた場合に、エラーが発生せずにスキップされるようになりました。

- **テスト**
  - 存在しないデータの削除操作がエラーにならないことを確認するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->