### PR TITLE
Bump version to 0.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [tool.poetry]
 authors = ["medaka0213"]
 name = "ddb_single"
-version = "0.5.5"
+version = "0.5.6"
 description = "Python DynamoDB interface, specialized in single-table design."
 license = "MIT"
 homepage = "https://medaka0213.github.io/DynamoDB-SingleTable/"


### PR DESCRIPTION
Bump version to 0.5.6
### [0.5.6](https://github.com/medaka0213/DynamoDB-SingleTable/compare/v0.5.5...v0.5.6) (2025-08-25)


### Bug Fixes

* search_keyフィールドの値が正しく検索レコードに反映されない問題を修正 ([#78](https://github.com/medaka0213/DynamoDB-SingleTable/issues/78)) ([8a2f2ad](https://github.com/medaka0213/DynamoDB-SingleTable/commit/8a2f2ad2a9eeb7dad1c5ef8dc40f2b12edc9766e))


### Build Systems

* **deps:** bump amazon/dynamodb-local from 2.6.1 to 3.0.0 ([#77](https://github.com/medaka0213/DynamoDB-SingleTable/issues/77)) ([948f20f](https://github.com/medaka0213/DynamoDB-SingleTable/commit/948f20fd2b850b6bcdfedfc8c458dc466189b26d))