### PR TITLE
Add CLI to rebuild search records

### DIFF
--- a/ddb_single/_cli.py
+++ b/ddb_single/_cli.py
@@ -66,5 +66,6 @@ def apply_model_change(module: str) -> None:
         # エラーが発生した場合はCLIエラーとして出力
         raise click.ClickException(str(exc))
 
+
 if __name__ == "__main__":
     cli()

--- a/ddb_single/_cli.py
+++ b/ddb_single/_cli.py
@@ -66,11 +66,5 @@ def apply_model_change(module: str) -> None:
         # エラーが発生した場合はCLIエラーとして出力
         raise click.ClickException(str(exc))
 
-
-def main() -> None:
-    """Entry point for console script."""
-    cli()
-
-
 if __name__ == "__main__":
-    main()
+    cli()

--- a/ddb_single/_cli.py
+++ b/ddb_single/_cli.py
@@ -1,0 +1,76 @@
+import importlib
+import inspect
+from typing import Dict, Type
+
+import click
+
+from ddb_single.model import BaseModel
+from ddb_single.query import Query
+from ddb_single.table import Table
+
+
+def apply_model_change_records(module_path: str) -> None:
+    """Regenerate search records for all table items to reflect model changes.
+
+    Args:
+        module_path (str): Python module path that defines a :class:`Table` instance
+            named ``table`` and the corresponding :class:`BaseModel` classes.
+    """
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as exc:
+        # モジュールが見つからなかった場合はエラー
+        raise ValueError("module not found") from exc
+
+    table = getattr(module, "table", None)
+    if not isinstance(table, Table):
+        # テーブルが見つからなかった場合はエラー
+        raise ValueError("table instance not found in module")
+
+    models: Dict[str, Type[BaseModel]] = {}
+    for obj in module.__dict__.values():
+        if inspect.isclass(obj) and issubclass(obj, BaseModel):
+            # 同じテーブルに属するモデルのみ収集
+            if getattr(obj, "__table__", None) == table:
+                models[obj.__model_name__] = obj
+
+    for item in table.all_items():
+        model_name = table.pk2model(item[table.__primary_key__])
+        model_cls = models.get(model_name)
+        if model_cls is None:
+            # 対応するモデルが存在しない場合はスキップ
+            continue
+        model = model_cls(__skip_validation__=True, **item)
+        query = Query(table, model)
+        add_items, rm_items = query._search_items()
+        if add_items:
+            # 足りない検索レコードを追加
+            table.batch_create(add_items)
+        if rm_items:
+            # 不要な検索レコードを削除
+            table.batch_delete_items(rm_items)
+
+
+@click.group()
+def cli() -> None:
+    """Command line interface for DynamoDB SingleTable."""
+
+
+@cli.command("apply-model-change")
+@click.argument("module")
+def apply_model_change(module: str) -> None:
+    """Rebuild search records for all items after model changes."""
+    try:
+        apply_model_change_records(module)
+    except ValueError as exc:
+        # エラーが発生した場合はCLIエラーとして出力
+        raise click.ClickException(str(exc))
+
+
+def main() -> None:
+    """Entry point for console script."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ readme = "readme.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 boto3 = "^1.34.79"
+click = "^8.1"
 
 [tool.poetry.dev-dependencies]
 
@@ -23,6 +24,9 @@ sphinx-rtd-theme = "^2.0.0"
 pyproject-flake8 = "^6.1.0"
 pytest-cov = "^5.0.0"
 myst-parser = "^2.0.0"
+
+[tool.poetry.scripts]
+ddb_single = "ddb_single._cli:cli"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/models_for_cli.py
+++ b/tests/models_for_cli.py
@@ -1,0 +1,22 @@
+import datetime
+import logging
+from ddb_single.table import Table
+from ddb_single.model import BaseModel, DBField
+
+logging.basicConfig(level=logging.INFO)
+
+table = Table(
+    table_name="table_cli_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    endpoint_url="http://localhost:8000",
+    region_name="us-west-2",
+    aws_access_key_id="fakeMyKeyId",
+    aws_secret_access_key="fakeSecretAccessKey",
+)
+table.init()
+
+
+class User(BaseModel):
+    __table__ = table
+    __model_name__ = "user"
+    name = DBField(unique_key=True)
+    email = DBField(search_key=True)

--- a/tests/test_cli_apply_model_change.py
+++ b/tests/test_cli_apply_model_change.py
@@ -1,0 +1,48 @@
+import unittest
+from boto3.dynamodb.conditions import Key
+from click.testing import CliRunner
+from ddb_single.table import SearchExpression
+import ddb_single.utils_botos as util_b
+from ddb_single.query import Query
+import ddb_single._cli as cli_mod
+
+from tests.models_for_cli import table, User
+
+
+class TestApplyModelChangeRecords(unittest.TestCase):
+    def setUp(self):
+        self.query = Query(table)
+        user = User(name="alice", email="alice@example.com")
+        q = self.query.model(user)
+        search_items, _ = q._search_items()
+        q.create()
+        table.batch_delete_items(search_items)
+
+    def test_apply_model_change_records(self):
+        searchEx = [
+            SearchExpression(
+                FilterStatus=util_b.FilterStatus.STAGED,
+                IndexName=table.__search_index__,
+                KeyConditionExpression=Key("sk").eq("search_user_email")
+                & Key("data").eq("alice@example.com"),
+            )
+        ]
+        res = table.search("user", *searchEx)
+        self.assertEqual(len(res), 0)
+        runner = CliRunner()
+        result = runner.invoke(cli_mod.cli, ["apply-model-change", "tests.models_for_cli"])
+        self.assertEqual(result.exit_code, 0)
+
+        res = table.search("user", *searchEx)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["email"], "alice@example.com")
+
+    def test_apply_model_change_records_invalid_module(self):
+        runner = CliRunner()
+        result = runner.invoke(cli_mod.cli, ["apply-model-change", "tests.missing_module"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("module not found", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- migrate CLI parsing to click and expose `apply-model-change` command
- add `click` dependency and console script entry
- test CLI including error case for missing module

## Testing
- `poetry run pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_68acfae41180832fbd922fabdd86c8e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - モデル変更後に検索レコードを再生成するCLIを追加。指定モジュールからテーブルと紐づくモデルを検出し、必要な検索レコードの追加・削除をバッチで反映します。無効なモジュールやテーブル未定義時はユーザー向けのエラーメッセージを表示します。
- テスト
  - CLIの正常系・異常系テストを追加。実行前後で検索結果が反映されることと、存在しないモジュール指定時のエラー終了を検証します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->