### PR TITLE
Bump version to 0.5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [tool.poetry]
 authors = ["medaka0213"]
 name = "ddb_single"
-version = "0.5.7"
+version = "0.5.8"
 description = "Python DynamoDB interface, specialized in single-table design."
 license = "MIT"
 homepage = "https://medaka0213.github.io/DynamoDB-SingleTable/"


### PR DESCRIPTION
Bump version to 0.5.8
### [0.5.8](https://github.com/medaka0213/DynamoDB-SingleTable/compare/v0.5.7...v0.5.8) (2025-08-26)


### Bug Fixes

* apply_model_change_records to accept BaseModel classes directly ([#84](https://github.com/medaka0213/DynamoDB-SingleTable/issues/84)) ([c10dacb](https://github.com/medaka0213/DynamoDB-SingleTable/commit/c10dacb25093e3fc3c119d8a21d33fd5d0e8231e))