### PR TITLE
[codex] sync ddb-guppy query validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ shared-local-instance.db
 docs
 poetry.lock
 .claude
-test_*.py
+/test_*.py

--- a/ddb_single/key_condition_util.py
+++ b/ddb_single/key_condition_util.py
@@ -1,0 +1,81 @@
+"""Utilities for DynamoDB KeyConditionExpression validation."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Iterable
+
+from ddb_single.error import InvalidParameterError
+
+_LEAF_TYPES = frozenset(
+    {
+        "Equals",
+        "LessThan",
+        "LessThanEquals",
+        "LessThanOrEqualTo",
+        "GreaterThan",
+        "GreaterThanEquals",
+        "GreaterThanOrEqualTo",
+        "BeginsWith",
+        "Between",
+    }
+)
+
+
+def _condition_subnodes(condition) -> tuple:
+    """Return boto3 condition children tuple; fail fast if the shape is unexpected."""
+    values = getattr(condition, "_values", None)
+    if values is None:
+        raise InvalidParameterError(
+            "Unsupported KeyConditionExpression node (missing _values): %s"
+            % type(condition).__name__
+        )
+    if not isinstance(values, tuple):
+        raise InvalidParameterError(
+            "Unsupported KeyConditionExpression node (_values is not a tuple): %s"
+            % type(condition).__name__
+        )
+    return values
+
+
+def iter_key_attributes_used_in_key_condition(condition) -> Iterable[str]:
+    """Yield key attribute names referenced in a boto3 KeyConditionExpression tree."""
+    if condition is None:
+        return
+    cls_name = condition.__class__.__name__
+    if cls_name in ("And", "Or"):
+        for sub in _condition_subnodes(condition):
+            yield from iter_key_attributes_used_in_key_condition(sub)
+        return
+    if cls_name == "Not":
+        inner = _condition_subnodes(condition)
+        if inner:
+            yield from iter_key_attributes_used_in_key_condition(inner[0])
+        return
+    if cls_name in _LEAF_TYPES:
+        values = getattr(condition, "_values", None)
+        if values is None or len(values) == 0:
+            raise InvalidParameterError(
+                "Unsupported KeyConditionExpression leaf (missing _values): %s"
+                % cls_name
+            )
+        key_or_attr = values[0]
+        name = getattr(key_or_attr, "name", None)
+        if name is not None:
+            yield name
+        return
+    raise InvalidParameterError(
+        "Unsupported KeyConditionExpression node type: %s" % cls_name
+    )
+
+
+def validate_single_condition_per_key(condition) -> None:
+    """Raise when the same key attribute is constrained more than once."""
+    names = list(iter_key_attributes_used_in_key_condition(condition))
+    counts = Counter(names)
+    dups = sorted(k for k, v in counts.items() if v > 1)
+    if dups:
+        raise InvalidParameterError(
+            "KeyConditionExpression uses multiple conditions for the same key attribute(s): %s"
+            % ", ".join(dups)
+        )

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -9,6 +9,11 @@ import uuid
 from enum import Enum
 
 import ddb_single.utils_botos as util_b
+from ddb_single.error import InvalidParameterError
+from ddb_single.key_condition_util import (
+    iter_key_attributes_used_in_key_condition,
+    validate_single_condition_per_key,
+)
 
 import logging
 
@@ -38,6 +43,18 @@ def default_pk_factory(model_name):
 
 def default_sk_factory(model_name, prefix="", suffix="_item"):
     return f"{prefix}{model_name}{suffix}"
+
+
+def _coerce_search_expression_filter_status(ex: "SearchExpression") -> None:
+    """Normalize string FilterStatus values into enum members."""
+    fs = ex.FilterStatus
+    if fs is None or isinstance(fs, util_b.FilterStatus):
+        return
+    if isinstance(fs, str):
+        for member in util_b.FilterStatus:
+            if member.value == fs or member.name == fs:
+                ex.FilterStatus = member
+                return
 
 
 def default_pk2model(pk):
@@ -213,37 +230,74 @@ class Table:
         limit = kwargs.get("Limit") or float("inf")
         try:
             response = self.__table__.scan(**kwargs)
-        except ClientError:
-            logger.error("ClientError", exc_info=True)
-        else:
-            if "Items" in response:
-                res_data = response["Items"]
-                while "LastEvaluatedKey" in response and len(res_data) < limit:
-                    logger.debug(f"pagenation: {len(res_data)}/{limit}")
-                    response = self.__table__.scan(
-                        **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
-                    )
-                    res_data += response["Items"]
-                return util_b.json_export(res_data)
-            else:
-                return []
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_msg = e.response.get("Error", {}).get("Message", "No message")
+            logger.error(
+                f"DynamoDB Scan failed with {error_code}: {error_msg}",
+                extra={
+                    "error_code": error_code,
+                    "error_message": error_msg,
+                    "index_name": kwargs.get("IndexName"),
+                    "filter_expression": str(kwargs.get("FilterExpression"))
+                    if kwargs.get("FilterExpression")
+                    else None,
+                },
+                exc_info=True,
+            )
+            if error_code == "ValidationException":
+                raise
+            return []
+
+        if "Items" in response:
+            res_data = response["Items"]
+            while "LastEvaluatedKey" in response and len(res_data) < limit:
+                logger.debug(f"pagination: {len(res_data)}/{limit}")
+                response = self.__table__.scan(
+                    **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
+                )
+                res_data += response["Items"]
+            return util_b.json_export(res_data)
+        return []
 
     def query(self, **kwargs) -> list[dict]:
         """クエリ"""
         limit = kwargs.get("Limit") or float("inf")
+        kce = kwargs.get("KeyConditionExpression")
+        if kce is not None:
+            validate_single_condition_per_key(kce)
         try:
             response = self.__table__.query(**kwargs)
-        except ClientError:
-            logger.error("ClientError", exc_info=True)
-        else:
-            if len(response["Items"]):
-                res_data = response["Items"]
-                while "LastEvaluatedKey" in response and len(res_data) < limit:
-                    response = self.__table__.query(
-                        **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
-                    )
-                    res_data += response["Items"]
-                return util_b.json_export(res_data)
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_msg = e.response.get("Error", {}).get("Message", "No message")
+            logger.error(
+                f"DynamoDB Query failed with {error_code}: {error_msg}",
+                extra={
+                    "error_code": error_code,
+                    "error_message": error_msg,
+                    "index_name": kwargs.get("IndexName"),
+                    "key_condition_expression": str(kwargs.get("KeyConditionExpression"))
+                    if kwargs.get("KeyConditionExpression")
+                    else None,
+                    "filter_expression": str(kwargs.get("FilterExpression"))
+                    if kwargs.get("FilterExpression")
+                    else None,
+                },
+                exc_info=True,
+            )
+            if error_code == "ValidationException":
+                raise
+            return []
+
+        if len(response["Items"]):
+            res_data = response["Items"]
+            while "LastEvaluatedKey" in response and len(res_data) < limit:
+                response = self.__table__.query(
+                    **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
+                )
+                res_data += response["Items"]
+            return util_b.json_export(res_data)
         return []
 
     def get_item(self, pk, sk=None):
@@ -331,10 +385,9 @@ class Table:
         """関連先を検索"""
         logger.debug(f"pk: {pk}, model_name: {model_name}, field_name: {field_name}")
         KeyConditionExpression = Key(self.__primary_key__).eq(pk)
-        if model_name:
-            KeyConditionExpression &= Key(self.__secondary_key__).begins_with(
-                self.rel_prefix(model_name)
-            )
+        KeyConditionExpression &= Key(self.__secondary_key__).begins_with(
+            self.rel_prefix(model_name)
+        )
         if field_name:
             # フィールドの指定がある場合
             res = self.query(
@@ -394,10 +447,8 @@ class Table:
             return items
         res = []
         for item in items:
-            for searchEx in searchExs:
-                if searchEx.FilterMethod(item):
-                    res.append(item)
-                    break
+            if all(searchEx.FilterMethod(item) for searchEx in searchExs):
+                res.append(item)
         return res
 
     def search(
@@ -417,6 +468,8 @@ class Table:
             SearchExpression(**ex) if isinstance(ex, dict) else ex
             for ex in searchEx
         ]
+        for ex in searchEx:
+            _coerce_search_expression_filter_status(ex)
         simple_ex: list[SearchExpression] = [
             ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.SEARCH
         ]
@@ -431,6 +484,14 @@ class Table:
             for ex in searchEx
             if ex.FilterStatus == util_b.FilterStatus.FILTER_STAGED
         ]
+        bucketed_ids = {id(ex) for ex in simple_ex + staged_ex + filter_ex + filter_ex_staged}
+        orphan = [ex for ex in searchEx if id(ex) not in bucketed_ids]
+        if orphan:
+            logger.warning(
+                "Ignored %d search expression(s) with unrecognized FilterStatus: %s",
+                len(orphan),
+                [ex.FilterStatus for ex in orphan],
+            )
         logger.debug(
             f"Expressions ... simple: {simple_ex}, staged: {staged_ex}, filter: {filter_ex}, filter_staged: {filter_ex_staged}"  # noqa
         )
@@ -471,8 +532,7 @@ class Table:
 
             # filter_ex があればフィルタ
             res = self.batch_get_from_pks(list(res))
-            if staged_ex and filter_ex:
-                logger.debug("Both staged_ex and filter_ex found. Filtering items...")
+            if filter_ex:
                 res = self.filter(res, filter_ex)
             if limit is not None:
                 res = list(res)[:limit]
@@ -483,7 +543,17 @@ class Table:
         # シンプルにクエリ検索
         KeyConditionExpression = Key(self.__secondary_key__).eq(self.sk(model_name))
         for ex in simple_ex:
-            KeyConditionExpression &= ex.KeyConditionExpression
+            sub_kce = ex.KeyConditionExpression
+            if sub_kce is None:
+                continue
+            sub_names = set(iter_key_attributes_used_in_key_condition(sub_kce))
+            if not sub_names.issubset({self.__primary_key__}):
+                raise InvalidParameterError(
+                    "SEARCH KeyConditionExpression must reference only the primary key attribute %r; got %s"
+                    % (self.__primary_key__, sorted(sub_names))
+                )
+            KeyConditionExpression &= sub_kce
+        validate_single_condition_per_key(KeyConditionExpression)
         if filter_ex:
             _res = (
                 self.query(

--- a/tests/test_duplicate_key_condition.py
+++ b/tests/test_duplicate_key_condition.py
@@ -1,0 +1,47 @@
+import datetime
+import unittest
+
+from boto3.dynamodb.conditions import Key
+
+from ddb_single.error import InvalidParameterError
+from ddb_single.table import Table
+
+
+table = Table(
+    table_name="duplicate_key_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    endpoint_url="http://localhost:8000",
+    region_name="us-west-2",
+    aws_access_key_id="fakeMyKeyId",
+    aws_secret_access_key="fakeSecretAccessKey",
+)
+
+
+class TestDuplicateKeyCondition(unittest.TestCase):
+    def test_duplicate_range_key_condition(self):
+        invalid_key_condition = (
+            Key("sk").eq("search_testModel_name")
+            & Key("data").eq("test1")
+            & Key("data").eq("test1")
+        )
+
+        with self.assertRaises(InvalidParameterError) as context:
+            table.query(
+                KeyConditionExpression=invalid_key_condition,
+                IndexName="DataSearchIndex",
+            )
+
+        self.assertIn("multiple conditions", str(context.exception).lower())
+        self.assertIn("data", str(context.exception).lower())
+
+    def test_multiple_different_conditions_same_key(self):
+        invalid_key_condition = (
+            Key("sk").eq("search_testModel_name")
+            & Key("data").eq("test1")
+            & Key("data").begins_with("test")
+        )
+
+        with self.assertRaises(InvalidParameterError):
+            table.query(
+                KeyConditionExpression=invalid_key_condition,
+                IndexName="DataSearchIndex",
+            )

--- a/tests/test_key_condition_util.py
+++ b/tests/test_key_condition_util.py
@@ -1,0 +1,75 @@
+import unittest
+
+from boto3.dynamodb.conditions import Key
+
+from ddb_single import utils_botos as util_b
+from ddb_single.error import InvalidParameterError
+from ddb_single.key_condition_util import (
+    iter_key_attributes_used_in_key_condition,
+    validate_single_condition_per_key,
+)
+from ddb_single.table import SearchExpression, Table, _coerce_search_expression_filter_status
+
+
+class TestKeyConditionUtil(unittest.TestCase):
+    def test_iter_single_partition_and_sort(self):
+        kce = Key("sk").eq("search_user_name") & Key("data").eq("x")
+        self.assertEqual(
+            sorted(iter_key_attributes_used_in_key_condition(kce)), ["data", "sk"]
+        )
+
+    def test_iter_detects_duplicate_keys(self):
+        kce = Key("sk").eq("a") & Key("data").eq("x") & Key("sk").eq("b")
+        names = list(iter_key_attributes_used_in_key_condition(kce))
+        self.assertEqual(names.count("sk"), 2)
+        self.assertEqual(names.count("data"), 1)
+
+    def test_validate_accepts_valid_gsi_key(self):
+        kce = Key("sk").eq("search_rocket_name") & Key("data").eq("falcon")
+        validate_single_condition_per_key(kce)
+
+    def test_validate_accepts_lte_gte_boto3_class_names(self):
+        kce = Key("sk").eq("search_user_age") & Key("data-n").lte(15)
+        validate_single_condition_per_key(kce)
+        kce = Key("sk").eq("search_user_age") & Key("data-n").gte(10)
+        validate_single_condition_per_key(kce)
+
+    def test_validate_rejects_duplicate_data(self):
+        kce = Key("sk").eq("search_model_name") & Key("data").eq("v") & Key("data").eq("w")
+        with self.assertRaises(InvalidParameterError) as ctx:
+            validate_single_condition_per_key(kce)
+        self.assertIn("data", str(ctx.exception))
+
+    def test_iter_rejects_unknown_node_type(self):
+        class UnknownCondition:
+            pass
+
+        with self.assertRaises(InvalidParameterError):
+            list(iter_key_attributes_used_in_key_condition(UnknownCondition()))
+
+    def test_coerce_filter_status_string_staged(self):
+        ex = SearchExpression(FilterStatus="staged")
+        _coerce_search_expression_filter_status(ex)
+        self.assertIs(ex.FilterStatus, util_b.FilterStatus.STAGED)
+
+    def test_coerce_filter_status_enum_unchanged(self):
+        ex = SearchExpression(FilterStatus=util_b.FilterStatus.FILTER)
+        _coerce_search_expression_filter_status(ex)
+        self.assertIs(ex.FilterStatus, util_b.FilterStatus.FILTER)
+
+    def test_search_simple_path_rejects_gsi_shape_on_search_status(self):
+        table = Table(
+            table_name="t",
+            endpoint_url="http://localhost:8000",
+            region_name="us-west-2",
+            aws_access_key_id="f",
+            aws_secret_access_key="f",
+        )
+        bad = SearchExpression(
+            FilterStatus=util_b.FilterStatus.SEARCH,
+            KeyConditionExpression=Key("sk").eq("search_user_name")
+            & Key("data").eq("v"),
+        )
+        with self.assertRaises(InvalidParameterError) as ctx:
+            table.search("user", bad)
+        self.assertIn("primary key", str(ctx.exception).lower())

--- a/tests/test_validation_exception_handling.py
+++ b/tests/test_validation_exception_handling.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import MagicMock
+
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+
+from ddb_single.table import Table
+
+
+class TestValidationExceptionHandling(unittest.TestCase):
+    def test_query_validation_exception_is_reraised(self):
+        table = Table(
+            table_name="test_table",
+            endpoint_url="http://localhost:8000",
+            region_name="us-west-2",
+            aws_access_key_id="fakeMyKeyId",
+            aws_secret_access_key="fakeSecretAccessKey",
+        )
+        mock_boto_table = MagicMock()
+        error_response = {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "Invalid KeyConditionExpression: KeyConditionExpressions must only contain one condition per key",
+            },
+            "ResponseMetadata": {"RequestId": "test-request-id"},
+        }
+        mock_boto_table.query.side_effect = ClientError(error_response, "Query")
+        table.__table__ = mock_boto_table
+
+        with self.assertRaises(ClientError) as context:
+            table.query(KeyConditionExpression=Key("pk").eq("x"))
+
+        self.assertEqual(
+            context.exception.response["Error"]["Code"], "ValidationException"
+        )
+
+    def test_query_other_client_errors_return_empty_list(self):
+        table = Table(
+            table_name="test_table",
+            endpoint_url="http://localhost:8000",
+            region_name="us-west-2",
+            aws_access_key_id="fakeMyKeyId",
+            aws_secret_access_key="fakeSecretAccessKey",
+        )
+        mock_boto_table = MagicMock()
+        error_response = {
+            "Error": {
+                "Code": "ProvisionedThroughputExceededException",
+                "Message": "The level of configured provisioned throughput for the table was exceeded",
+            },
+            "ResponseMetadata": {"RequestId": "test-request-id"},
+        }
+        mock_boto_table.query.side_effect = ClientError(error_response, "Query")
+        table.__table__ = mock_boto_table
+
+        result = table.query(KeyConditionExpression=Key("pk").eq("x"))
+        self.assertEqual(result, [])
+
+    def test_scan_validation_exception_is_reraised(self):
+        table = Table(
+            table_name="test_table",
+            endpoint_url="http://localhost:8000",
+            region_name="us-west-2",
+            aws_access_key_id="fakeMyKeyId",
+            aws_secret_access_key="fakeSecretAccessKey",
+        )
+        mock_boto_table = MagicMock()
+        error_response = {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "Invalid scan parameters",
+            },
+            "ResponseMetadata": {"RequestId": "test-request-id"},
+        }
+        mock_boto_table.scan.side_effect = ClientError(error_response, "Scan")
+        table.__table__ = mock_boto_table
+
+        with self.assertRaises(ClientError) as context:
+            table.scan()
+
+        self.assertEqual(
+            context.exception.response["Error"]["Code"], "ValidationException"
+        )


### PR DESCRIPTION
## Summary
- sync the useful `ddb-guppy` query-validation fixes into this repository
- reject duplicate key conditions before issuing DynamoDB queries
- re-raise DynamoDB `ValidationException` instead of swallowing it as an empty result
- add regression tests for key-condition validation and validation-exception handling
- narrow `.gitignore` so new tests under `tests/` are tracked

## Why
The comparison target had behavior fixes that are relevant here: duplicate `KeyConditionExpression` fragments could reach DynamoDB and fail at runtime, and `ValidationException` could be hidden behind an empty-list fallback. This PR ports those defensive checks and adds coverage for the regressions.

## Impact
- invalid query shapes now fail fast with `InvalidParameterError`
- `scan()` and `query()` preserve DynamoDB validation failures for callers
- staged/filter search combinations now apply filters consistently
- relation lookup always applies the relation-prefix bound

## Validation
- `python -m py_compile ddb_single/table.py ddb_single/key_condition_util.py tests/test_key_condition_util.py tests/test_duplicate_key_condition.py tests/test_validation_exception_handling.py`
- full test execution was not run in this shell because `poetry` / `pytest` / `boto3` are not installed here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * クエリとスキャンのエラーハンドリングが改善されました。検証エラーは再スローされ、その他のエラーは空リストを返すようになります。
  * フィルター機能が「すべての述語が一致」（AND）に変更されました。
  * キー条件検証が強化され、重複する条件がある場合は検出されます。

* **テスト**
  * キー条件検証とエラーハンドリングをカバーする包括的なテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->