### PR TITLE
feat: search-index fallback, reletion→relation rename (backward compatible), and safety fixes

### DIFF
--- a/ddb_single/__init__.py
+++ b/ddb_single/__init__.py
@@ -1,8 +1,14 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 try:
     from ddb_single.model import BaseModel, DBField  # noqa: F401
-    from ddb_single.table import Table  # noqa: F401
     from ddb_single.query import Query, apply_model_change_records  # noqa: F401
-except Exception:
-    pass
+    from ddb_single.table import Table  # noqa: F401
+except ImportError:
+    # 依存パッケージが未インストールでも import 自体は成功させる。
+    # ImportError 以外の例外は握り潰さず、そのまま送出する (#399)
+    logger.error("ddb_single の依存パッケージが見つからないため、一部シンボルを公開できません", exc_info=True)
 
 __VERSION__ = "0.0.0"

--- a/ddb_single/_cli.py
+++ b/ddb_single/_cli.py
@@ -1,11 +1,15 @@
 import importlib
 import inspect
+import re
 
 import click
 
 from ddb_single.model import BaseModel
 from ddb_single.query import apply_model_change_records
 from ddb_single.table import Table
+
+# Python のモジュールパスとして妥当な形式のみ許可する（任意コード実行の防止） (#399)
+_MODULE_PATH_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
 
 
 def _apply_model_change_records_from_path(module_path: str) -> None:
@@ -18,6 +22,10 @@ def _apply_model_change_records_from_path(module_path: str) -> None:
         module_path (str): Python module path that defines a :class:`Table` instance
             named ``table`` and the corresponding :class:`BaseModel` classes.
     """
+    if not _MODULE_PATH_PATTERN.fullmatch(module_path):
+        # 英数・アンダースコア・ドット区切り以外のパスは import しない
+        raise ValueError("invalid module path")
+
     try:
         module = importlib.import_module(module_path)
     except ModuleNotFoundError as exc:

--- a/ddb_single/error.py
+++ b/ddb_single/error.py
@@ -1,5 +1,4 @@
 class DDBSingleError(Exception):
-
     def __init__(self, message):
         self.message = message
 
@@ -8,19 +7,16 @@ class DDBSingleError(Exception):
 
 
 class ValidationError(DDBSingleError):
-
     def __str__(self):
-        return f"Falied to validate: {self.message}"
+        return f"Failed to validate: {self.message}"
 
 
 class InvalidParameterError(DDBSingleError):
-
     def __str__(self):
         return f"Invalid parameter: {self.message}"
 
 
 class NotFoundError(DDBSingleError):
-
     def __init__(self, message):
         super().__init__(message)
 

--- a/ddb_single/key_condition_util.py
+++ b/ddb_single/key_condition_util.py
@@ -7,6 +7,7 @@ from typing import Iterable
 
 from ddb_single.error import InvalidParameterError
 
+# boto3 uses *Equals suffix for lte/gte (not *OrEqualTo). Include both spellings for compatibility.
 _LEAF_TYPES = frozenset(
     {
         "Equals",
@@ -27,19 +28,22 @@ def _condition_subnodes(condition) -> tuple:
     values = getattr(condition, "_values", None)
     if values is None:
         raise InvalidParameterError(
-            "Unsupported KeyConditionExpression node (missing _values): %s"
-            % type(condition).__name__
+            "Unsupported KeyConditionExpression node (missing _values): %s" % type(condition).__name__
         )
     if not isinstance(values, tuple):
         raise InvalidParameterError(
-            "Unsupported KeyConditionExpression node (_values is not a tuple): %s"
-            % type(condition).__name__
+            "Unsupported KeyConditionExpression node (_values is not a tuple): %s" % type(condition).__name__
         )
     return values
 
 
 def iter_key_attributes_used_in_key_condition(condition) -> Iterable[str]:
-    """Yield key attribute names referenced in a boto3 KeyConditionExpression tree."""
+    """Yield attribute names referenced by Key() leaves in a condition tree.
+
+    DynamoDB requires at most one condition function per key attribute in
+    KeyConditionExpression. This iterator collects names so callers can detect
+    duplicates before calling ``Query``.
+    """
     if condition is None:
         return
     cls_name = condition.__class__.__name__
@@ -55,27 +59,21 @@ def iter_key_attributes_used_in_key_condition(condition) -> Iterable[str]:
     if cls_name in _LEAF_TYPES:
         values = getattr(condition, "_values", None)
         if values is None or len(values) == 0:
-            raise InvalidParameterError(
-                "Unsupported KeyConditionExpression leaf (missing _values): %s"
-                % cls_name
-            )
+            raise InvalidParameterError("Unsupported KeyConditionExpression leaf (missing _values): %s" % cls_name)
         key_or_attr = values[0]
         name = getattr(key_or_attr, "name", None)
         if name is not None:
             yield name
         return
-    raise InvalidParameterError(
-        "Unsupported KeyConditionExpression node type: %s" % cls_name
-    )
+    raise InvalidParameterError("Unsupported KeyConditionExpression node type: %s" % cls_name)
 
 
 def validate_single_condition_per_key(condition) -> None:
-    """Raise when the same key attribute is constrained more than once."""
+    """Raise InvalidParameterError if the same key attribute appears more than once."""
     names = list(iter_key_attributes_used_in_key_condition(condition))
     counts = Counter(names)
     dups = sorted(k for k, v in counts.items() if v > 1)
     if dups:
         raise InvalidParameterError(
-            "KeyConditionExpression uses multiple conditions for the same key attribute(s): %s"
-            % ", ".join(dups)
+            "KeyConditionExpression uses multiple conditions for the same key attribute(s): %s" % ", ".join(dups)
         )

--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -1,12 +1,13 @@
-from decimal import Decimal
-from boto3.dynamodb.conditions import Key
 import hashlib
+import logging
+import warnings
+from decimal import Decimal
 
-from ddb_single.table import FieldType, Table, SearchExpression
+from boto3.dynamodb.conditions import Key
+
 import ddb_single.utils_botos as util_b
 from ddb_single.error import ValidationError
-
-import logging
+from ddb_single.table import FieldType, SearchExpression, Table
 
 logger = logging.getLogger(__name__)
 
@@ -29,8 +30,8 @@ class DBField:
         secondary_key=False,
         unique_key=False,
         search_key=False,
-        reletion=None,
-        reletion_by_unique=True,
+        relation=None,
+        relation_by_unique=True,
         relation_raise_if_not_found=False,
         ignore_case=False,
         **kwargs,
@@ -46,11 +47,29 @@ class DBField:
             secondary_key (bool): Whether the field is a secondary key.
             unique_key (bool): Whether the field is a unique key.
             search_key (bool): Whether the field is a search key.
-            reletion (BaseModel): The reletion model of the field.
+            relation (BaseModel): The relation model of the field.
             reference (BaseModel): The reference model of the field.
-            reletion_by_unique (bool): Whether the reletion is by unique key.
+            relation_by_unique (bool): Whether the relation is by unique key.
             relation_raise_if_not_found (bool): Whether to raise an error if the relation is not found.
         """
+        # 後方互換: 綴り違いの ``reletion`` / ``reletion_by_unique`` を受け付ける (deprecated)。
+        # 明示された正しい引数が優先される。
+        if "reletion" in kwargs:
+            warnings.warn(
+                "DBField(reletion=...) is deprecated; use relation=... instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            legacy_relation = kwargs.pop("reletion")
+            if relation is None:
+                relation = legacy_relation
+        if "reletion_by_unique" in kwargs:
+            warnings.warn(
+                "DBField(reletion_by_unique=...) is deprecated; use relation_by_unique=... instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            relation_by_unique = kwargs.pop("reletion_by_unique")
         self.type = type
         self.default = default
         self.default_factory = default_factory
@@ -60,11 +79,10 @@ class DBField:
         self.secondary_key = secondary_key
         self.unique_key = unique_key
         self.search_key = search_key or unique_key
-        self.relation = reletion
-        self.reletion_by_unique = reletion_by_unique
+        self.relation = relation
+        self.relation_by_unique = relation_by_unique
         self.relation_raise_if_not_found = relation_raise_if_not_found
         self.ignore_case = ignore_case
-        self.value = None
 
     def setup(self, name, model_cls):
         self.__model_cls__ = model_cls
@@ -98,7 +116,7 @@ class DBField:
             "unique_key": self.unique_key,
             "search_key": self.search_key,
             "relation": self.relation.__model_name__ if self.relation else None,
-            "reletion_by_unique": self.reletion_by_unique,
+            "relation_by_unique": self.relation_by_unique,
             "ignore_case": self.ignore_case,
         }
 
@@ -110,49 +128,45 @@ class DBField:
         Returns:
             The validated value.
         """
-        # 先に必ずクリア
-        self.value = None
         self.__setup__ = True
 
         if value is not None:
-            self.value = value
+            val = value
         elif self.default is not None:
-            self.value = self.default
+            val = self.default
         elif self.default_factory:
-            self.value = self.default_factory(self.__model_cls__)
+            val = self.default_factory(self.__model_cls__)
         else:
             # どれもなければ None を明示
-            self.value = None
+            val = None
 
         if not skip:
             if value is None:
                 if not self.nullable:
                     raise ValidationError(f"Not nullable: {self.__class__.__name__}")
             else:
-                self._setup_relation()
-                self.value = self._validate_value(self.value)
-        return self.value
+                val = self._setup_relation(val)
+                val = self._validate_value(val)
+        return val
 
-    def _setup_relation(self):
+    def _setup_relation(self, val):
         def extract_value(v, by_unique):
             types = str, bytes, int, float, Decimal, bool
             if not [t for t in types if isinstance(v, t)]:
                 if by_unique:
-                    return v.data[self.value.__unique_keys__[0]]
+                    return v.data[v.__unique_keys__[0]]
                 else:
-                    return v.data[self.value.__primary_key__]
+                    return v.data[v.__primary_key__]
             else:
                 return v
 
         if not self.is_list():
             if self.relation:
-                self.value = extract_value(self.value, self.reletion_by_unique)
+                val = extract_value(val, self.relation_by_unique)
         else:
             if self.relation:
-                self.value = [
-                    extract_value(v, self.reletion_by_unique) for v in self.value
-                ]
-        return self.value
+                val = [extract_value(v, self.relation_by_unique) for v in val]
+        return val
 
     def _validate_value(self, value):
         field_name = getattr(self, "name", "DBField")
@@ -205,9 +219,7 @@ class DBField:
         Returns:
             str: The search key of the field.
         """
-        return self.__table__.search_key_factory(
-            self.__model_cls__.__model_name__, self.name
-        )
+        return self.__table__.search_key_factory(self.__model_cls__.__model_name__, self.name)
 
     def search_data_key(self):
         """
@@ -223,14 +235,15 @@ class DBField:
         """
         return self.__table__.search_index(self.type)
 
-    def search_item(self, pk):
+    def search_item(self, pk, value):
         """
         Args:
             pk: The primary key of the item.
+            value: The value to generate search items for.
         Returns:
             list[dict]: The search items.
         """
-        _value = self.value
+        _value = value
         if self.ignore_case and isinstance(_value, str):
             # lower case if self.ignore_case = True
             _value = _value.lower()
@@ -239,10 +252,7 @@ class DBField:
     def _build_search_items(self, pk, value):
         """Build search items, chunking large search keys when necessary."""
         # 文字列が大きすぎる場合はチャンク保存に切り替える
-        if (
-            isinstance(value, str)
-            and len(value.encode("utf-8")) > self.__table__.search_key_max_bytes
-        ):
+        if isinstance(value, str) and len(value.encode("utf-8")) > self.__table__.search_key_max_bytes:
             return self._chunked_search_items(pk, value)
 
         return [
@@ -265,10 +275,7 @@ class DBField:
             for char in text:
                 encoded = char.encode("utf-8")
                 # 1チャンクの最大サイズを超える場合は新しいチャンクを作る
-                if (
-                    current_bytes + len(encoded)
-                    > self.__table__.search_key_chunk_size
-                ):
+                if current_bytes + len(encoded) > self.__table__.search_key_chunk_size:
                     chunks.append("".join(current))
                     current = [char]
                     current_bytes = len(encoded)
@@ -304,10 +311,7 @@ class DBField:
 
     def _normalize_search_value(self, value):
         """Normalize search value, hashing long strings for index storage."""
-        if (
-            isinstance(value, str)
-            and len(value.encode("utf-8")) > self.__table__.search_key_max_bytes
-        ):
+        if isinstance(value, str) and len(value.encode("utf-8")) > self.__table__.search_key_max_bytes:
             # 長い文字列はハッシュ化してインデックスに保存する
             return hashlib.sha256(value.encode("utf-8")).hexdigest()
         return value
@@ -336,18 +340,44 @@ class DBField:
                 value = value.lower()
         normalized_value = self._normalize_search_value(value)
         if self.secondary_key:
-            raise ValidationError(
-                f"Secondary key should not be used as a key: {self.name}"
-            )
+            raise ValidationError(f"Secondary key should not be used as a key: {self.name}")
+
+        def _filter_method():
+            # NOTE: DynamoDB 側の検索では ignore_case を index 側の正規化で吸収しているが、
+            # フォールバック（in-memory filter）でも同じ判定になるようにする。
+            if self.ignore_case and isinstance(value, str):
+                target = value
+
+                def _m(x):
+                    got = x.get(self.name)
+                    if isinstance(got, str):
+                        got = got.lower()
+                    return util_b.attr_method(self.name, target, mode)({**x, self.name: got})
+
+                return _m
+            if self.ignore_case and isinstance(value, list):
+                target = value
+
+                def _m(x):
+                    got = x.get(self.name)
+                    if isinstance(got, str):
+                        got = got.lower()
+                    return util_b.attr_method(self.name, target, mode)({**x, self.name: got})
+
+                return _m
+            return util_b.attr_method(self.name, value, mode)
+
+        filter_method = _filter_method()
 
         if util_b.is_key(mode):
             if self.primary_key:
                 # PKを使う場合
-                logger.debug(
-                    f"KeyConditionExpression [primary key]: {self.name} = {value}, {mode}"
-                )
+                logger.debug(f"KeyConditionExpression [primary key]: {self.name} = {value}, {mode}")
                 return SearchExpression(
-                    FilterMethod=util_b.attr_method(self.name, value, mode),
+                    name=self.name,
+                    value=value,
+                    mode=mode,
+                    FilterMethod=filter_method,
                     KeyConditionExpression=util_b.range_ex(self.name, value, mode),
                     FilterStatus=util_b.FilterStatus.SEARCH,
                 )
@@ -356,35 +386,36 @@ class DBField:
                 KeyConditionExpression = Key(self.__table__.__secondary_key__).eq(
                     self.search_key_factory()
                 ) & util_b.range_ex(self.search_data_key(), normalized_value, mode)
-                logger.debug(
-                    f"KeyConditionExpression [search key]: {self.search_data_key()} = {value}, {mode}"
-                )
+                logger.debug(f"KeyConditionExpression [search key]: {self.search_data_key()} = {value}, {mode}")
                 return SearchExpression(
-                    FilterMethod=util_b.attr_method(self.name, value, mode),
+                    name=self.name,
+                    value=value,
+                    mode=mode,
+                    FilterMethod=filter_method,
                     KeyConditionExpression=KeyConditionExpression,
                     IndexName=self.search_index(),
                     FilterStatus=util_b.FilterStatus.STAGED,
                 )
         elif self.search_key:
             # SearchKeyを使うが、Queryで使えない方法で検索する場合
-            logger.debug(
-                f"FilterExpression [search key]: {self.search_data_key()} = {value}, {mode}"
-            )
+            logger.debug(f"FilterExpression [search key]: {self.search_data_key()} = {value}, {mode}")
             return SearchExpression(
-                FilterMethod=util_b.attr_method(self.name, value, mode),
-                KeyConditionExpression=Key(self.__table__.__secondary_key__).eq(
-                    self.search_key_factory()
-                ),
+                name=self.name,
+                value=value,
+                mode=mode,
+                FilterMethod=filter_method,
+                KeyConditionExpression=Key(self.__table__.__secondary_key__).eq(self.search_key_factory()),
                 IndexName=self.__table__.__range_index_name__,
-                FilterExpression=util_b.attr_ex(
-                    self.search_data_key(), normalized_value, mode
-                ),
+                FilterExpression=util_b.attr_ex(self.search_data_key(), normalized_value, mode),
                 FilterStatus=util_b.FilterStatus.FILTER_STAGED,
             )
         # SearchKeyを使わない場合
         logger.debug(f"FilterExpression: {self.name} = {value}, {mode}")
         return SearchExpression(
-            FilterMethod=util_b.attr_method(self.name, value, mode),
+            name=self.name,
+            value=value,
+            mode=mode,
+            FilterMethod=filter_method,
             FilterExpression=util_b.attr_ex(self.name, value, mode),
             FilterStatus=util_b.FilterStatus.FILTER,
         )
@@ -537,9 +568,7 @@ class BaseModel:
                 if v.relation:
                     self.__relation_keys__.append(k)
         if not self.__unique_keys__ and self.__use_unique_for_relations__:
-            raise ValidationError(
-                f"Missing unique keys for relation: {self.__model_name__}"
-            )
+            raise ValidationError(f"Missing unique keys for relation: {self.__model_name__}")
         self.__setup__ = True
 
     def get_field(self, key: str) -> DBField:

--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -141,7 +141,7 @@ class DBField:
             val = None
 
         if not skip:
-            if value is None:
+            if val is None:
                 if not self.nullable:
                     raise ValidationError(f"Not nullable: {self.__class__.__name__}")
             else:
@@ -381,7 +381,7 @@ class DBField:
                     KeyConditionExpression=util_b.range_ex(self.name, value, mode),
                     FilterStatus=util_b.FilterStatus.SEARCH,
                 )
-            elif self.search_key and value:
+            elif self.search_key and value is not None and not (isinstance(value, (str, bytes)) and len(value) == 0):
                 # SearchKey を使う場合は検索用 GSI を活用し、ユニーク検索が確実にヒットするようにする
                 KeyConditionExpression = Key(self.__table__.__secondary_key__).eq(
                     self.search_key_factory()

--- a/ddb_single/query.py
+++ b/ddb_single/query.py
@@ -305,7 +305,7 @@ class Query:
                     pks.append(x)
                 elif field.relation_raise_if_not_found:
                     # 存在しない場合はエラー
-                    raise NotFoundError(f"{self.__model__.__model_name__}={x}")
+                    raise NotFoundError(f"{field.relation.__model_name__}={x}")
         # Primary key が None のものを除外して、関連アイテムを作成
         pks = [pk for pk in pks if pk is not None]
         result = [self._relation_item(pk, field) for pk in pks]

--- a/ddb_single/query.py
+++ b/ddb_single/query.py
@@ -1,10 +1,10 @@
-from typing import Optional, List, Dict, Type
+import logging
+from typing import Dict, List, Optional, Type
+
+import ddb_single.utils_botos as util_b
+from ddb_single.error import NotFoundError, ValidationError
 from ddb_single.model import BaseModel, DBField
 from ddb_single.table import Table
-import ddb_single.utils_botos as util_b
-from ddb_single.error import ValidationError, NotFoundError
-
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -39,31 +39,16 @@ class Query:
             field: DBField = self.__model__.__class__.__dict__[k]
             value = self.__model__.data.get(k)
             if k in self.__model__.data.keys() and value:
-                # Set the field value before calling search_item
-                field.value = value
-                items_add.extend(
-                    field.search_item(
-                        self.__model__.data[self.__model__.__primary_key__]
-                    )
-                )
+                items_add.extend(field.search_item(self.__model__.data[self.__model__.__primary_key__], value))
             else:
-                # Set None for removal
-                field.value = None
-                items_remove.extend(
-                    field.search_item(
-                        self.__model__.data[self.__model__.__primary_key__]
-                    )
-                )
+                items_remove.extend(field.search_item(self.__model__.data[self.__model__.__primary_key__], None))
 
             if previous_data is not None:
                 prev_value = previous_data.get(k)
                 # 以前の値と異なる場合は過去の検索アイテムを削除対象に追加する
                 if prev_value and prev_value != value:
-                    field.value = prev_value
                     items_remove.extend(
-                        field.search_item(
-                            self.__model__.data[self.__model__.__primary_key__]
-                        )
+                        field.search_item(self.__model__.data[self.__model__.__primary_key__], prev_value)
                     )
         return items_add, items_remove
 
@@ -74,9 +59,7 @@ class Query:
         Args:
             queries (List[dict]): Query objects
         """
-        return self.__table__.search(
-            self.__model__.__model_name__, *queries, pk_only=pk_only, limit=limit
-        )
+        return self.__table__.search(self.__model__.__model_name__, *queries, pk_only=pk_only, limit=limit)
 
     def get(self, pk: str):
         """
@@ -87,9 +70,7 @@ class Query:
         res = self.__table__.get_item(pk)
         return res
 
-    def get_by_unique(
-        self, value, pk_only=False, keys: List[str | DBField] = None
-    ) -> dict:
+    def get_by_unique(self, value, pk_only=False, keys: List[str | DBField] = None) -> dict:
         """
         ユニークキーで取得
         Args:
@@ -112,9 +93,7 @@ class Query:
                 # 指定されたキー以外はスキップ
                 logger.warning(f"get_by_unique: {key} not in {specified_keys} ... skip")
                 continue
-            _res = self.search(
-                getattr(self.__model__.__class__, key).eq(value), pk_only=pk_only
-            )
+            _res = self.search(getattr(self.__model__.__class__, key).eq(value), pk_only=pk_only)
             logger.debug(f"get_by_unique: {key}={value} result={_res}")
             res.extend(_res)
         if res:
@@ -130,9 +109,7 @@ class Query:
         res = self.__table__.batch_get_from_pks(pks)
         return res
 
-    def batch_get_by_unique(
-        self, uniques: List[str], pk_only=False, keys: List[str | DBField] = None
-    ):
+    def batch_get_by_unique(self, uniques: List[str], pk_only=False, keys: List[str | DBField] = None):
         """
         ユニークキーのリストから一括取得
         Args:
@@ -151,13 +128,9 @@ class Query:
         for key in self.__model__.__unique_keys__:
             if specified_keys and key not in specified_keys:
                 # 指定されたキー以外はスキップ
-                logger.warning(
-                    f"batch_get_by_unique: {key} not in {specified_keys} ... skip"
-                )
+                logger.warning(f"batch_get_by_unique: {key} not in {specified_keys} ... skip")
                 continue
-            _res = self.search(
-                getattr(self.__model__.__class__, key).in_(uniques), pk_only=pk_only
-            )
+            _res = self.search(getattr(self.__model__.__class__, key).in_(uniques), pk_only=pk_only)
             logger.debug(f"batch_get_by_unique: {key} in {uniques} result={_res}")
             res.extend(_res)
         return res
@@ -175,9 +148,7 @@ class Query:
             batch: BatchWriteItem
             raise_if_exists (bool): Throw ValidationError if item already exists
         """
-        old_item = self.get_by_unique(
-            self.__model__.data[self.__model__.__unique_keys__[0]]
-        )
+        old_item = self.get_by_unique(self.__model__.data[self.__model__.__unique_keys__[0]])
         if old_item:
             if raise_if_exists:
                 raise ValidationError("Item Already exists")
@@ -193,9 +164,7 @@ class Query:
             target: Target item
             batch: BatchWriteItem
         """
-        payload = self.get_by_unique(
-            self.__model__.data[self.__model__.__unique_keys__[0]]
-        )
+        payload = self.get_by_unique(self.__model__.data[self.__model__.__unique_keys__[0]])
         if payload:
             self._update(payload, target or {}, batch=batch)
         else:
@@ -236,12 +205,8 @@ class Query:
     def _update(self, old_item, new_item, batch=None):
         previous_data = old_item.copy()
         self.__model__.data = {**old_item, **self.__model__.data, **new_item}
-        self.__model__.data[self.__model__.__primary_key__] = old_item[
-            self.__model__.__primary_key__
-        ]
-        self.__model__.data[self.__model__.__secondary_key__] = old_item[
-            self.__model__.__secondary_key__
-        ]
+        self.__model__.data[self.__model__.__primary_key__] = old_item[self.__model__.__primary_key__]
+        self.__model__.data[self.__model__.__secondary_key__] = old_item[self.__model__.__secondary_key__]
         if not util_b.is_same_json(old_item, self.__model__.data):
             self._create(
                 batch=batch,
@@ -267,9 +232,7 @@ class Query:
         target = target or self.__model__.data
         if target.get(self.__model__.__unique_keys__[0]):
             # unique があれば unique で削除
-            self.delete_by_unique(
-                target[self.__model__.__unique_keys__[0]], batch=batch
-            )
+            self.delete_by_unique(target[self.__model__.__unique_keys__[0]], batch=batch)
         elif target.get(self.__model__.__primary_key__):
             # pk があれば pk で削除
             self.delete_by_pk(target[self.__model__.__primary_key__], batch=batch)
@@ -294,16 +257,12 @@ class Query:
     def _relation_item(self, pk, field: DBField):
         """関連付け"""
         return {
-            self.__model__.__primary_key__: self.__model__.data[
-                self.__model__.__primary_key__
-            ],
+            self.__model__.__primary_key__: self.__model__.data[self.__model__.__primary_key__],
             self.__model__.__secondary_key__: self.__table__.rel_key(pk),
             self.__table__.__search_data_key__: field.name,
         }
 
-    def _get_other_item_by_unique(
-        self, target: BaseModel, value, table=None, default=None
-    ):
+    def _get_other_item_by_unique(self, target: BaseModel, value, table=None, default=None):
         q = Query(table or self.__table__, target)
         res = q.get_by_unique(value)
         return res
@@ -311,30 +270,39 @@ class Query:
     def _field2relation_items(self, field: DBField, value):
         if not value:
             # 空の場合は空リストを返す
+            logger.info(f"_field2relation_items: field={field.name}, value is empty")
             return []
 
         pks = []
         if not field.is_list():
             # リストでない場合はリストに変換
             value = [value]
-        if field.reletion_by_unique:
+        if field.relation_by_unique:
             # Unique Key で関連付け
             rel: BaseModel = field.relation()
+            logger.info(f"_field2relation_items: field={field.name}, relation={rel.__model_name__}, values={value}")
             for x in value:
                 # Unique Key で関連アイテムを取得
                 _rel_item = self._get_other_item_by_unique(rel, x, default={})
                 if _rel_item:
-                    pks.append(_rel_item.get(rel.__primary_key__))
-                elif field.relation_raise_if_not_found:
-                    # 存在しない場合はエラー
-                    raise NotFoundError(f"{rel.__model_name__}={x}")
+                    pk = _rel_item.get(rel.__primary_key__)
+                    logger.info(f"_field2relation_items: Found relation item for {x}: pk={pk}")
+                    pks.append(pk)
+                else:
+                    logger.warning(
+                        f"_field2relation_items: Relation item NOT FOUND for {field.name}={x} (model={rel.__model_name__})"
+                    )
+                    if field.relation_raise_if_not_found:
+                        # 存在しない場合はエラー
+                        raise NotFoundError(f"{rel.__model_name__}={x}")
         else:
             # Primary key で関連付け
             for x in value:
-                pk = self.get(pk=x)
-                if pk:
+                # x is already a PK, just verify it exists
+                item = self.get(pk=x)
+                if item:
                     # 存在するものだけ追加
-                    pks.append(pk)
+                    pks.append(x)
                 elif field.relation_raise_if_not_found:
                     # 存在しない場合はエラー
                     raise NotFoundError(f"{self.__model__.__model_name__}={x}")
@@ -346,30 +314,34 @@ class Query:
     def _relation_items(self):
         items_add = []
         items_exist = []
+        # 関連キー(スキーマ上のフィールド名)はデバッグ用途のみ DEBUG で出力する。
+        # 実データ値は PII を含む恐れがあるためログに出さない。
+        logger.debug(
+            "_relation_items CALLED: model=%s, relation_keys_count=%d, relation_keys=%s",
+            self.__model__.__model_name__,
+            len(self.__model__.__relation_keys__),
+            self.__model__.__relation_keys__,
+        )
         for k in self.__model__.__relation_keys__:
             field: DBField = self.__model__.__class__.__dict__[k]
             rel: BaseModel = field.relation
+            logger.debug("_relation_items: Processing field=%s, relation=%s", k, rel.__model_name__)
             _items_exist = self.__table__.relation(
                 self.__model__.data[self.__model__.__primary_key__], rel.__model_name__
             )
-            _items_exist = [
-                self._relation_item(i[self.__table__.__primary_key__], field)
-                for i in _items_exist
-            ]
+            logger.debug("_relation_items: Found %d existing relation items for %s", len(_items_exist), k)
+            _items_exist = [self._relation_item(i[self.__table__.__primary_key__], field) for i in _items_exist]
             if k in self.__model__.data.keys():
                 _items_add = self._field2relation_items(field, self.__model__.data[k])
+                logger.debug("_relation_items: Created %d new relation items for %s", len(_items_add), k)
                 items_add.extend(_items_add)
             items_exist.extend(_items_exist)
         sk_add = [item[self.__model__.__secondary_key__] for item in items_add]
         sk_exist = [item[self.__model__.__secondary_key__] for item in items_exist]
         # 削除 .. 既存のリストから追加リストを引く
-        items_remove = [
-            i for i in items_exist if i[self.__model__.__secondary_key__] not in sk_add
-        ]
+        items_remove = [i for i in items_exist if i[self.__model__.__secondary_key__] not in sk_add]
         # 追加 .. 追加リストから既存のリストを引く
-        items_add = [
-            i for i in items_add if i[self.__model__.__secondary_key__] not in sk_exist
-        ]
+        items_add = [i for i in items_add if i[self.__model__.__secondary_key__] not in sk_exist]
         return items_add, items_remove
 
     def get_relation(self, model: BaseModel = "", field: DBField = "", pk_only=False):
@@ -416,20 +388,14 @@ def apply_model_change_records(table: Table, models: List[Type[BaseModel]]) -> N
     model_map: Dict[str, Type[BaseModel]] = {}
     for model_cls in models:
         if not (isinstance(model_cls, type) and issubclass(model_cls, BaseModel)):
-            raise ValueError(
-                f"All models must be BaseModel subclasses, got {model_cls}"
-            )
+            raise ValueError(f"All models must be BaseModel subclasses, got {model_cls}")
 
         # Ensure the model belongs to the specified table
         if getattr(model_cls, "__table__", None) != table:
-            raise ValueError(
-                f"Model {model_cls.__name__} does not belong to the specified table"
-            )
+            raise ValueError(f"Model {model_cls.__name__} does not belong to the specified table")
 
         if not hasattr(model_cls, "__model_name__"):
-            raise ValueError(
-                f"Model {model_cls.__name__} must have __model_name__ attribute"
-            )
+            raise ValueError(f"Model {model_cls.__name__} must have __model_name__ attribute")
 
         model_map[model_cls.__model_name__] = model_cls
 

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -1,12 +1,15 @@
-from functools import reduce
+import logging
 import operator
-import boto3
-from boto3.dynamodb.conditions import Key, Attr
-from botocore.exceptions import ClientError
-from dataclasses import dataclass
+import os
 import time
 import uuid
+from dataclasses import dataclass
 from enum import Enum
+from functools import reduce
+
+import boto3
+from boto3.dynamodb.conditions import Attr, Key
+from botocore.exceptions import ClientError
 
 import ddb_single.utils_botos as util_b
 from ddb_single.error import InvalidParameterError
@@ -14,8 +17,6 @@ from ddb_single.key_condition_util import (
     iter_key_attributes_used_in_key_condition,
     validate_single_condition_per_key,
 )
-
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +46,8 @@ def default_sk_factory(model_name, prefix="", suffix="_item"):
     return f"{prefix}{model_name}{suffix}"
 
 
-def _coerce_search_expression_filter_status(ex: "SearchExpression") -> None:
-    """Normalize string FilterStatus values into enum members."""
+def _coerce_search_expression_filter_status(ex: SearchExpression) -> None:
+    """Normalize FilterStatus when callers pass a plain string instead of FilterStatus enum."""
     fs = ex.FilterStatus
     if fs is None or isinstance(fs, util_b.FilterStatus):
         return
@@ -119,6 +120,9 @@ class Table:
         WriteCapacityUnits=1,
         **table_kwargs,
     ):
+        env_url = os.environ.get("DYNAMODB_ENDPOINT_URL")
+        if env_url:
+            table_kwargs["endpoint_url"] = env_url
         self.__recourse__ = boto3.resource("dynamodb", **table_kwargs)
         self.__client__ = boto3.client("dynamodb", **table_kwargs)
         self.__table_name__ = table_name
@@ -156,9 +160,7 @@ class Table:
         return self.__primary_key2model__(pk)
 
     def sk(self, model_name):
-        return self.__secondary_key_factory__(
-            model_name, self.__secondary_key_prefix__, self.__secondary_key_suffix__
-        )
+        return self.__secondary_key_factory__(model_name, self.__secondary_key_prefix__, self.__secondary_key_suffix__)
 
     def sk2model(self, sk):
         return sk[
@@ -233,6 +235,8 @@ class Table:
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
             error_msg = e.response.get("Error", {}).get("Message", "No message")
+
+            # Log detailed information about the scan that failed
             logger.error(
                 f"DynamoDB Scan failed with {error_code}: {error_msg}",
                 extra={
@@ -245,17 +249,21 @@ class Table:
                 },
                 exc_info=True,
             )
+
+            # ValidationException indicates a problem with the scan parameters,
+            # Re-raise it so the caller can handle it appropriately.
             if error_code == "ValidationException":
                 raise
+
+            # For other errors, return empty list (existing behavior)
             return []
 
+        # Process successful scan response
         if "Items" in response:
             res_data = response["Items"]
             while "LastEvaluatedKey" in response and len(res_data) < limit:
                 logger.debug(f"pagination: {len(res_data)}/{limit}")
-                response = self.__table__.scan(
-                    **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
-                )
+                response = self.__table__.scan(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
                 res_data += response["Items"]
             return util_b.json_export(res_data)
         return []
@@ -271,6 +279,8 @@ class Table:
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
             error_msg = e.response.get("Error", {}).get("Message", "No message")
+
+            # Log detailed information about the query that failed
             logger.error(
                 f"DynamoDB Query failed with {error_code}: {error_msg}",
                 extra={
@@ -286,16 +296,20 @@ class Table:
                 },
                 exc_info=True,
             )
+
+            # ValidationException indicates a problem with the query structure itself,
+            # not just "no data found". Re-raise it so the caller can handle it appropriately.
             if error_code == "ValidationException":
                 raise
+
+            # For other errors, return empty list (existing behavior)
             return []
 
+        # Process successful query response
         if len(response["Items"]):
             res_data = response["Items"]
             while "LastEvaluatedKey" in response and len(res_data) < limit:
-                response = self.__table__.query(
-                    **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
-                )
+                response = self.__table__.query(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
                 res_data += response["Items"]
             return util_b.json_export(res_data)
         return []
@@ -317,9 +331,7 @@ class Table:
         res = util_b.json_export(res)
         return res
 
-    def _batch_get_item(
-        self, key_list: list[dict], sleep_time=0.5, max_tries=5
-    ) -> list:
+    def _batch_get_item(self, key_list: list[dict], sleep_time=0.5, max_tries=5) -> list:
         """アイテムをバッチで取得"""
         # リストが空なら空リストを返す
         if not key_list or len(key_list) == 0:
@@ -328,12 +340,8 @@ class Table:
         table_name = self.__table_name__
         key_list = [
             {
-                self.__primary_key__: {
-                    self.__primary_key_type__: k[self.__primary_key__]
-                },
-                self.__secondary_key__: {
-                    self.__secondary_key_type__: k[self.__secondary_key__]
-                },
+                self.__primary_key__: {self.__primary_key_type__: k[self.__primary_key__]},
+                self.__secondary_key__: {self.__secondary_key_type__: k[self.__secondary_key__]},
             }
             for k in key_list
         ]
@@ -343,12 +351,8 @@ class Table:
         batch_keys = {table_name: {"Keys": key_list}}
 
         while tries < max_tries:
-            batch_get_item_response = self.__client__.batch_get_item(
-                RequestItems=batch_keys
-            )
-            dynamo_table_data += batch_get_item_response["Responses"].get(
-                table_name, []
-            )
+            batch_get_item_response = self.__client__.batch_get_item(RequestItems=batch_keys)
+            dynamo_table_data += batch_get_item_response["Responses"].get(table_name, [])
             unprocessed_key = batch_get_item_response["UnprocessedKeys"]
             if unprocessed_key:
                 batch_keys = unprocessed_key
@@ -374,10 +378,7 @@ class Table:
 
     def batch_get_from_pks(self, pks: list[str]) -> list[dict]:
         """pksからアイテムをバッチで取得"""
-        keys = [
-            {self.__primary_key__: pk, self.__secondary_key__: self.pk2sk(pk)}
-            for pk in pks
-        ]
+        keys = [{self.__primary_key__: pk, self.__secondary_key__: self.pk2sk(pk)} for pk in pks]
         return self.batch_get(keys)
 
     # --- 検索関連 ---
@@ -385,9 +386,8 @@ class Table:
         """関連先を検索"""
         logger.debug(f"pk: {pk}, model_name: {model_name}, field_name: {field_name}")
         KeyConditionExpression = Key(self.__primary_key__).eq(pk)
-        KeyConditionExpression &= Key(self.__secondary_key__).begins_with(
-            self.rel_prefix(model_name)
-        )
+        # Always apply prefix filter
+        KeyConditionExpression &= Key(self.__secondary_key__).begins_with(self.rel_prefix(model_name))
         if field_name:
             # フィールドの指定がある場合
             res = self.query(
@@ -414,8 +414,7 @@ class Table:
         if field_name:
             # フィールドの指定がある場合
             res = self.query(
-                KeyConditionExpression=KeyConditionExpression
-                & Key(self.__search_data_key__).eq(field_name),
+                KeyConditionExpression=KeyConditionExpression & Key(self.__search_data_key__).eq(field_name),
                 FilterExpression=Attr(self.__primary_key__).begins_with(model_name),
                 IndexName=self.__search_index__,
                 ProjectionExpression=self.__primary_key__,
@@ -423,8 +422,7 @@ class Table:
         elif model_name:
             # モデルの指定がある場合
             res = self.query(
-                KeyConditionExpression=KeyConditionExpression
-                & Key(self.__primary_key__).begins_with(model_name),
+                KeyConditionExpression=KeyConditionExpression & Key(self.__primary_key__).begins_with(model_name),
                 IndexName=self.__range_index_name__,
                 ProjectionExpression=self.__primary_key__,
             )
@@ -451,9 +449,54 @@ class Table:
                 res.append(item)
         return res
 
-    def search(
-        self, model_name, *searchEx: SearchExpression, pk_only=False, limit=None
-    ):
+    def _query_staged_pks(self, ex: SearchExpression, model_name):
+        """staged 検索を実行して対象の primary key リストを返す。
+
+        一部の環境で SearchIndex (DataSearchIndex) クエリが
+        ValidationException: "KeyConditionExpressions must only contain one condition per key"
+        になる事象が報告されている。その場合は RangeIndex でモデルの候補を引き、
+        in-memory filter にフォールバックする。
+        """
+        try:
+            _res = (
+                self.query(
+                    KeyConditionExpression=ex.KeyConditionExpression,
+                    IndexName=ex.IndexName,
+                    ProjectionExpression=self.__primary_key__,
+                )
+                or []
+            )
+            return [r[self.__primary_key__] for r in _res]
+        except (InvalidParameterError, ClientError) as e:
+            error_code = ""
+            if isinstance(e, ClientError):
+                error_code = e.response.get("Error", {}).get("Code", "")
+            if not (isinstance(e, InvalidParameterError) or error_code == "ValidationException"):
+                raise
+            logger.warning(
+                "SearchIndex query failed; falling back to in-memory filter. model=%s field=%s mode=%s",
+                model_name,
+                getattr(ex, "name", None),
+                getattr(ex, "mode", None),
+                exc_info=True,
+            )
+            candidates = (
+                self.query(
+                    KeyConditionExpression=Key(self.__secondary_key__).eq(self.sk(model_name)),
+                    IndexName=self.__range_index_name__,
+                    ProjectionExpression=self.__primary_key__,
+                )
+                or []
+            )
+            candidate_pks = [r[self.__primary_key__] for r in candidates]
+            if not candidate_pks:
+                return []
+            if ex.FilterMethod is None:
+                return candidate_pks
+            items = self.batch_get_from_pks(candidate_pks)
+            return [it[self.__primary_key__] for it in items if ex.FilterMethod(it)]
+
+    def search(self, model_name, *searchEx: SearchExpression, pk_only=False, limit=None):
         """Search items
         Args:
             model_name (str): model name
@@ -470,19 +513,11 @@ class Table:
         ]
         for ex in searchEx:
             _coerce_search_expression_filter_status(ex)
-        simple_ex: list[SearchExpression] = [
-            ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.SEARCH
-        ]
-        staged_ex: list[SearchExpression] = [
-            ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.STAGED
-        ]
-        filter_ex: list[SearchExpression] = [
-            ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.FILTER
-        ]
+        simple_ex: list[SearchExpression] = [ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.SEARCH]
+        staged_ex: list[SearchExpression] = [ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.STAGED]
+        filter_ex: list[SearchExpression] = [ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.FILTER]
         filter_ex_staged: list[SearchExpression] = [
-            ex
-            for ex in searchEx
-            if ex.FilterStatus == util_b.FilterStatus.FILTER_STAGED
+            ex for ex in searchEx if ex.FilterStatus == util_b.FilterStatus.FILTER_STAGED
         ]
         bucketed_ids = {id(ex) for ex in simple_ex + staged_ex + filter_ex + filter_ex_staged}
         orphan = [ex for ex in searchEx if id(ex) not in bucketed_ids]
@@ -493,21 +528,17 @@ class Table:
                 [ex.FilterStatus for ex in orphan],
             )
         logger.debug(
-            f"Expressions ... simple: {simple_ex}, staged: {staged_ex}, filter: {filter_ex}, filter_staged: {filter_ex_staged}"  # noqa
+            "Expressions ... simple: %s, staged: %s, filter: %s, filter_staged: %s",
+            simple_ex,
+            staged_ex,
+            filter_ex,
+            filter_ex_staged,
         )
         if staged_ex + filter_ex_staged:
             res = set()
             for i, ex in enumerate(staged_ex):
                 # staged_ex があればフィルタ
-                _res = (
-                    self.query(
-                        KeyConditionExpression=ex.KeyConditionExpression,
-                        IndexName=ex.IndexName,
-                        ProjectionExpression=self.__primary_key__,
-                    )
-                    or []
-                )
-                _res = [r[self.__primary_key__] for r in _res]
+                _res = self._query_staged_pks(ex, model_name)
                 if i:
                     res &= set(_res)
                 else:
@@ -531,6 +562,8 @@ class Table:
                     res = set(_res)
 
             # filter_ex があればフィルタ
+            if not res:
+                return []
             res = self.batch_get_from_pks(list(res))
             if filter_ex:
                 res = self.filter(res, filter_ex)
@@ -558,9 +591,7 @@ class Table:
             _res = (
                 self.query(
                     KeyConditionExpression=KeyConditionExpression,
-                    FilterExpression=reduce(
-                        operator.and_, (ex.FilterExpression for ex in filter_ex)
-                    ),
+                    FilterExpression=reduce(operator.and_, (ex.FilterExpression for ex in filter_ex)),
                     IndexName=self.__range_index_name__,
                     ProjectionExpression=self.__primary_key__,
                 )
@@ -602,9 +633,7 @@ class Table:
         item = util_b.json_import(item)
         if not old_item and not batch:
             # 単一の処理で、既存のアイテムがない場合は、既存のアイテムを取得する
-            old_item = self.get_item(
-                item[self.__primary_key__], item[self.__secondary_key__]
-            )
+            old_item = self.get_item(item[self.__primary_key__], item[self.__secondary_key__])
         if old_item:
             new_item = {**old_item, **item}
             if not util_b.is_same_json(old_item, new_item):
@@ -633,11 +662,7 @@ class Table:
         old_items = self.batch_get(items)
         new_items = []
         for item in items:
-            old_item = [
-                i
-                for i in old_items
-                if i[self.__primary_key__] == item[self.__primary_key__]
-            ]
+            old_item = [i for i in old_items if i[self.__primary_key__] == item[self.__primary_key__]]
             if old_item:
                 old_item = old_item[0]
                 new_item = {**old_item, **item} if old_item else item
@@ -659,12 +684,8 @@ class Table:
         """バッチ処理"""
         logger.debug(f"batch_delete_items: {items}")
         # pk と pk が被っていたら除外 (set で重複を除外して辞書に変換)
-        items = set(
-            [(i[self.__primary_key__], i[self.__secondary_key__]) for i in items]
-        )
-        items = [
-            dict(zip([self.__primary_key__, self.__secondary_key__], i)) for i in items
-        ]
+        items = set([(i[self.__primary_key__], i[self.__secondary_key__]) for i in items])
+        items = [dict(zip([self.__primary_key__, self.__secondary_key__], i)) for i in items]
         if batch:
             for item in items:
                 self.detele_item(item, batch)
@@ -692,9 +713,7 @@ class Table:
         """関連付けを削除"""
         KeyConditionExpression = Key(self.__primary_key__).eq(pk)
         if model_name:
-            KeyConditionExpression &= Key(self.__secondary_key__).begins_with(
-                self.rel_prefix(model_name)
-            )
+            KeyConditionExpression &= Key(self.__secondary_key__).begins_with(self.rel_prefix(model_name))
         items = self.query(
             KeyConditionExpression=KeyConditionExpression,
             ProjectionExpression=f"{self.__primary_key__}, {self.__secondary_key__}",

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -121,7 +121,7 @@ class Table:
         **table_kwargs,
     ):
         env_url = os.environ.get("DYNAMODB_ENDPOINT_URL")
-        if env_url:
+        if env_url and "endpoint_url" not in table_kwargs:
             table_kwargs["endpoint_url"] = env_url
         self.__recourse__ = boto3.resource("dynamodb", **table_kwargs)
         self.__client__ = boto3.client("dynamodb", **table_kwargs)
@@ -227,62 +227,22 @@ class Table:
         """検索キーを分割する際の1チャンクあたりのバイト数"""
         return self.__search_key_chunk_size__
 
-    def scan(self, **kwargs) -> list[dict]:
-        """スキャン"""
-        limit = kwargs.get("Limit") or float("inf")
+    def _execute_boto_op(self, op, label, **kwargs):
+        """boto3 の scan/query を実行し、ページネーションを含めて統一的にエラーハンドリングする。
+
+        成功時はレスポンス(dict)を返す。ValidationException はクエリ自体の問題なので
+        呼び出し側で扱えるよう再送出し、それ以外の ClientError はログ出力のうえ None を返す
+        （= 呼び出し側は空扱いにする）。
+        """
         try:
-            response = self.__table__.scan(**kwargs)
+            return op(**kwargs)
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
             error_msg = e.response.get("Error", {}).get("Message", "No message")
 
-            # Log detailed information about the scan that failed
+            # 失敗したリクエストの詳細をログに残す
             logger.error(
-                f"DynamoDB Scan failed with {error_code}: {error_msg}",
-                extra={
-                    "error_code": error_code,
-                    "error_message": error_msg,
-                    "index_name": kwargs.get("IndexName"),
-                    "filter_expression": str(kwargs.get("FilterExpression"))
-                    if kwargs.get("FilterExpression")
-                    else None,
-                },
-                exc_info=True,
-            )
-
-            # ValidationException indicates a problem with the scan parameters,
-            # Re-raise it so the caller can handle it appropriately.
-            if error_code == "ValidationException":
-                raise
-
-            # For other errors, return empty list (existing behavior)
-            return []
-
-        # Process successful scan response
-        if "Items" in response:
-            res_data = response["Items"]
-            while "LastEvaluatedKey" in response and len(res_data) < limit:
-                logger.debug(f"pagination: {len(res_data)}/{limit}")
-                response = self.__table__.scan(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
-                res_data += response["Items"]
-            return util_b.json_export(res_data)
-        return []
-
-    def query(self, **kwargs) -> list[dict]:
-        """クエリ"""
-        limit = kwargs.get("Limit") or float("inf")
-        kce = kwargs.get("KeyConditionExpression")
-        if kce is not None:
-            validate_single_condition_per_key(kce)
-        try:
-            response = self.__table__.query(**kwargs)
-        except ClientError as e:
-            error_code = e.response.get("Error", {}).get("Code", "Unknown")
-            error_msg = e.response.get("Error", {}).get("Message", "No message")
-
-            # Log detailed information about the query that failed
-            logger.error(
-                f"DynamoDB Query failed with {error_code}: {error_msg}",
+                f"DynamoDB {label} failed with {error_code}: {error_msg}",
                 extra={
                     "error_code": error_code,
                     "error_message": error_msg,
@@ -297,19 +257,51 @@ class Table:
                 exc_info=True,
             )
 
-            # ValidationException indicates a problem with the query structure itself,
-            # not just "no data found". Re-raise it so the caller can handle it appropriately.
+            # ValidationException は「データが無い」ではなくリクエスト構造の問題なので再送出する
             if error_code == "ValidationException":
                 raise
 
-            # For other errors, return empty list (existing behavior)
+            # その他のエラーは空扱い（既存挙動）
+            return None
+
+    def scan(self, **kwargs) -> list[dict]:
+        """スキャン"""
+        limit = kwargs.get("Limit") or float("inf")
+        response = self._execute_boto_op(self.__table__.scan, "Scan", **kwargs)
+        if response is None:
             return []
 
-        # Process successful query response
+        if "Items" in response:
+            res_data = response["Items"]
+            while "LastEvaluatedKey" in response and len(res_data) < limit:
+                logger.debug(f"pagination: {len(res_data)}/{limit}")
+                response = self._execute_boto_op(
+                    self.__table__.scan, "Scan", **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
+                )
+                if response is None:
+                    break
+                res_data += response["Items"]
+            return util_b.json_export(res_data)
+        return []
+
+    def query(self, **kwargs) -> list[dict]:
+        """クエリ"""
+        limit = kwargs.get("Limit") or float("inf")
+        kce = kwargs.get("KeyConditionExpression")
+        if kce is not None:
+            validate_single_condition_per_key(kce)
+        response = self._execute_boto_op(self.__table__.query, "Query", **kwargs)
+        if response is None:
+            return []
+
         if len(response["Items"]):
             res_data = response["Items"]
             while "LastEvaluatedKey" in response and len(res_data) < limit:
-                response = self.__table__.query(**kwargs, ExclusiveStartKey=response["LastEvaluatedKey"])
+                response = self._execute_boto_op(
+                    self.__table__.query, "Query", **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
+                )
+                if response is None:
+                    break
                 res_data += response["Items"]
             return util_b.json_export(res_data)
         return []

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -294,7 +294,9 @@ class Table:
         if response is None:
             return []
 
-        if len(response["Items"]):
+        if "Items" in response:
+            # FilterExpression 付き Query は 1 ページ目が 0 件でも LastEvaluatedKey を返す
+            # ことがあるため、scan() と同様に LastEvaluatedKey ベースでページを辿る。
             res_data = response["Items"]
             while "LastEvaluatedKey" in response and len(res_data) < limit:
                 response = self._execute_boto_op(

--- a/ddb_single/utils_botos.py
+++ b/ddb_single/utils_botos.py
@@ -1,11 +1,13 @@
 # ddb_single/utils_botos.py
-from boto3.dynamodb.conditions import Key, Attr
-from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
-from ddb_single.error import InvalidParameterError
+from decimal import Decimal
 
 # クエリ設定のENUM
 from enum import Enum
-from decimal import Decimal
+
+from boto3.dynamodb.conditions import Attr, Key
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+
+from ddb_single.error import InvalidParameterError
 
 
 class QueryType(Enum):
@@ -99,8 +101,8 @@ def attr_method(name, value, mode):
         QueryType.LT_E: lambda x: x.get(name) <= value,
         QueryType.GT: lambda x: x.get(name) > value,
         QueryType.GT_E: lambda x: x.get(name) >= value,
-        QueryType.BEGINS: lambda x: x.get(name).startswith(value),
-        QueryType.CONTAINS: lambda x: value in x.get(name),
+        QueryType.BEGINS: lambda x: x.get(name) is not None and x.get(name).startswith(value),
+        QueryType.CONTAINS: lambda x: x.get(name) is not None and value in x.get(name),
         QueryType.IN: lambda x: x.get(name) in value,
         QueryType.N_EQ: lambda x: x.get(name) != value,
         QueryType.EX: lambda x: name in x,

--- a/docs_src/readme.md
+++ b/docs_src/readme.md
@@ -242,7 +242,7 @@ class BlogPost(BaseModel):
     __table__=table
     name = DBField(unique_key=True)
     content = DBField()
-    author = DBField(reletion=User)
+    author = DBField(relation=User)
 ```
 
 ### Create Item
@@ -257,7 +257,7 @@ blogpost = BlogPost(
 query.model(blogpost).create()
 ```
 
-Then, tha value "reletion item" added
+Then, the value "relation item" added
 
 |pk|sk|data|name|author|content|
 |-|-|-|-|-|-|
@@ -332,7 +332,7 @@ blogpost = BlogPost(**blogpost)
 query.model(blogpost).update()
 ```
 
-Then, "reletion item" changed
+Then, "relation item" changed
 
 |pk|sk|data|name|author|content|
 |-|-|-|-|-|-|
@@ -351,7 +351,7 @@ If related item deleted, relationship also deleted
 query.model(user).delete_by_unique("Michael")
 ```
 
-Then, "reletion item" deleted.
+Then, "relation item" deleted.
 But main item's value is not chenged.
 
 |pk|sk|data|name|author|content|

--- a/readme.md
+++ b/readme.md
@@ -255,7 +255,7 @@ class BlogPost(BaseModel):
     __table__=table
     name = DBField(unique_key=True)
     content = DBField()
-    author = DBField(reletion=User)
+    author = DBField(relation=User)
 ```
 
 ### Create Item
@@ -270,7 +270,7 @@ blogpost = BlogPost(
 query.model(blogpost).create()
 ```
 
-Then, tha value "reletion item" added
+Then, the value "relation item" added
 
 |pk|sk|data|name|author|content|
 |-|-|-|-|-|-|
@@ -345,7 +345,7 @@ blogpost = BlogPost(**blogpost)
 query.model(blogpost).update()
 ```
 
-Then, "reletion item" changed
+Then, "relation item" changed
 
 |pk|sk|data|name|author|content|
 |-|-|-|-|-|-|
@@ -364,7 +364,7 @@ If related item deleted, relationship also deleted
 query.model(user).delete_by_unique("Michael")
 ```
 
-Then, "reletion item" deleted.
+Then, "relation item" deleted.
 But main item's value is not chenged.
 
 |pk|sk|data|name|author|content|

--- a/tests/models_for_cli.py
+++ b/tests/models_for_cli.py
@@ -1,7 +1,8 @@
 import datetime
 import logging
-from ddb_single.table import Table
+
 from ddb_single.model import BaseModel, DBField
+from ddb_single.table import Table
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,13 +1,10 @@
+import datetime
+import logging
 import unittest
 
-from ddb_single.table import FieldType, Table
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-
-import datetime
-
-
-import logging
+from ddb_single.table import FieldType, Table
 
 logging.basicConfig(level=logging.INFO)
 

--- a/tests/test_cli_apply_model_change.py
+++ b/tests/test_cli_apply_model_change.py
@@ -1,12 +1,13 @@
 import unittest
+
+import ddb_single._cli as cli_mod
+import ddb_single.utils_botos as util_b
 from boto3.dynamodb.conditions import Key
 from click.testing import CliRunner
-from ddb_single.table import SearchExpression
-import ddb_single.utils_botos as util_b
 from ddb_single.query import Query
-import ddb_single._cli as cli_mod
+from ddb_single.table import SearchExpression
 
-from tests.models_for_cli import table, User
+from tests.models_for_cli import User, table  # noqa: I001
 
 
 class TestApplyModelChangeRecords(unittest.TestCase):
@@ -23,8 +24,7 @@ class TestApplyModelChangeRecords(unittest.TestCase):
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.STAGED,
                 IndexName=table.__search_index__,
-                KeyConditionExpression=Key("sk").eq("search_user_email")
-                & Key("data").eq("alice@example.com"),
+                KeyConditionExpression=Key("sk").eq("search_user_email") & Key("data").eq("alice@example.com"),
             )
         ]
         res = table.search("user", *searchEx)
@@ -42,6 +42,37 @@ class TestApplyModelChangeRecords(unittest.TestCase):
         result = runner.invoke(cli_mod.cli, ["apply-model-change", "tests.missing_module"])
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("module not found", result.output)
+
+
+class TestModulePathValidation(unittest.TestCase):
+    """importlib.import_module へ渡すモジュールパスの検証 (#399)。DB 接続不要"""
+
+    def test_apply_model_change_records_rejects_unsafe_module_path(self):
+        """モジュールパス以外の文字列は import 前に拒否される (#399)"""
+        unsafe_paths = [
+            "../evil",
+            "tests/models_for_cli",
+            "tests.models_for_cli;import os",
+            "tests.models_for_cli os.system('id')",
+            "tests..models_for_cli",
+            ".tests.models_for_cli",
+            "tests.models_for_cli.",
+            "123invalid",
+            "",
+            " ",
+        ]
+        runner = CliRunner()
+        for path in unsafe_paths:
+            with self.subTest(path=path):
+                result = runner.invoke(cli_mod.cli, ["apply-model-change", path])
+                self.assertNotEqual(result.exit_code, 0)
+                self.assertIn("invalid module path", result.output)
+
+    def test_module_path_pattern_allows_valid_paths(self):
+        """正当なモジュールパスはパターンを通過する (#399)"""
+        for path in ["tests.models_for_cli", "a", "a.b.c", "_private.module", "mod_1.sub_2"]:
+            with self.subTest(path=path):
+                self.assertIsNotNone(cli_mod._MODULE_PATH_PATTERN.fullmatch(path))
 
 
 if __name__ == "__main__":

--- a/tests/test_dbfield.py
+++ b/tests/test_dbfield.py
@@ -1,7 +1,9 @@
 import unittest
+import warnings
 from decimal import Decimal
-from ddb_single.model import DBField
+
 from ddb_single.error import ValidationError
+from ddb_single.model import DBField
 from ddb_single.table import FieldType
 
 
@@ -13,7 +15,6 @@ class DummyRelation:
 
 
 class TestDBFieldValidation(unittest.TestCase):
-
     def test_string_field_valid(self):
         field = DBField(type=FieldType.STRING, nullable=False)
         # Valid string input: returns the string as is.
@@ -64,6 +65,38 @@ class TestDBFieldValidation(unittest.TestCase):
         # A field that is not a list should not accept a list input.
         with self.assertRaises(ValidationError):
             field.validate(["not", "a", "string"])
+
+
+class TestDBFieldRelationBackwardCompat(unittest.TestCase):
+    """The misspelled ``reletion`` kwargs are deprecated but still accepted."""
+
+    def test_reletion_alias_maps_to_relation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            field = DBField(reletion=DummyRelation)
+        self.assertIs(field.relation, DummyRelation)
+        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
+    def test_reletion_by_unique_alias_maps_to_relation_by_unique(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            field = DBField(relation=DummyRelation, reletion_by_unique=False)
+        self.assertFalse(field.relation_by_unique)
+        self.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
+
+    def test_relation_takes_precedence_over_reletion(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            field = DBField(relation=DummyRelation, reletion=None)
+        self.assertIs(field.relation, DummyRelation)
+
+    def test_new_relation_kwarg_no_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            field = DBField(relation=DummyRelation, relation_by_unique=True)
+        self.assertIs(field.relation, DummyRelation)
+        self.assertTrue(field.relation_by_unique)
+        self.assertFalse(any(issubclass(w.category, DeprecationWarning) for w in caught))
 
 
 if __name__ == "__main__":

--- a/tests/test_dbfield.py
+++ b/tests/test_dbfield.py
@@ -66,6 +66,11 @@ class TestDBFieldValidation(unittest.TestCase):
         with self.assertRaises(ValidationError):
             field.validate(["not", "a", "string"])
 
+    def test_default_value_is_validated(self):
+        # A default supplied when no value is given must still be type-validated.
+        field = DBField(type=FieldType.NUMBER, default=5)
+        self.assertEqual(field.validate(None), Decimal("5"))
+
 
 class TestDBFieldRelationBackwardCompat(unittest.TestCase):
     """The misspelled ``reletion`` kwargs are deprecated but still accepted."""

--- a/tests/test_desc.py
+++ b/tests/test_desc.py
@@ -1,10 +1,10 @@
-import unittest
-from ddb_single.table import FieldType, Table
-from ddb_single.model import BaseModel, DBField
-from ddb_single.query import Query
-
 import datetime
 import logging
+import unittest
+
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import FieldType, Table
 
 logging.basicConfig(level=logging.INFO)
 
@@ -22,7 +22,7 @@ class User(BaseModel):
     __table__ = table
     __model_name__ = "user"
     name = DBField(unique_key=True)
-    name_ignore_nase = DBField(search_key=True, ignore_case=True)
+    name_ignore_case = DBField(search_key=True, ignore_case=True)
     email = DBField(search_key=True)
     age = DBField(type=FieldType.NUMBER, search_key=True)
     description = DBField()
@@ -34,7 +34,7 @@ class BlogPost(BaseModel):
     __table__ = table
     title = DBField(unique_key=True)
     content = DBField(search_key=True)
-    author = DBField(reletion=User)
+    author = DBField(relation=User)
 
 
 query = Query(table)
@@ -59,10 +59,10 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": True,
                         "search_key": True,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
-                    "name_ignore_nase": {
+                    "name_ignore_case": {
                         "type": "STRING",
                         "nullable": True,
                         "primary_key": False,
@@ -70,7 +70,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": False,
                         "search_key": True,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": True,
                     },
                     "email": {
@@ -81,7 +81,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": False,
                         "search_key": True,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
                     "age": {
@@ -92,7 +92,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": False,
                         "search_key": True,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
                     "description": {
@@ -103,7 +103,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": False,
                         "search_key": False,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
                     "config": {
@@ -114,7 +114,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": False,
                         "search_key": False,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
                 },
@@ -137,7 +137,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": True,
                         "search_key": True,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
                     "content": {
@@ -148,7 +148,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": False,
                         "search_key": True,
                         "relation": None,
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
                     "author": {
@@ -159,7 +159,7 @@ class TestCRUD(unittest.TestCase):
                         "unique_key": False,
                         "search_key": False,
                         "relation": "user",
-                        "reletion_by_unique": True,
+                        "relation_by_unique": True,
                         "ignore_case": False,
                     },
                 },

--- a/tests/test_duplicate_key_condition.py
+++ b/tests/test_duplicate_key_condition.py
@@ -1,11 +1,19 @@
+"""
+Tests for invalid KeyConditionExpression (duplicate key attributes).
+
+Previously DynamoDB returned ValidationException; ddb_single now rejects these
+before the API call (GitHub issue #967).
+"""
+
 import datetime
+import logging
 import unittest
 
 from boto3.dynamodb.conditions import Key
-
 from ddb_single.error import InvalidParameterError
 from ddb_single.table import Table
 
+logging.basicConfig(level=logging.DEBUG)
 
 table = Table(
     table_name="duplicate_key_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
@@ -17,11 +25,14 @@ table = Table(
 
 
 class TestDuplicateKeyCondition(unittest.TestCase):
+    """Invalid KeyConditionExpression is rejected before DynamoDB Query."""
+
     def test_duplicate_range_key_condition(self):
+        # sk = search_testModel_name AND data = test1 AND data = test1
         invalid_key_condition = (
             Key("sk").eq("search_testModel_name")
             & Key("data").eq("test1")
-            & Key("data").eq("test1")
+            & Key("data").eq("test1")  # Duplicate condition on 'data'
         )
 
         with self.assertRaises(InvalidParameterError) as context:
@@ -37,7 +48,7 @@ class TestDuplicateKeyCondition(unittest.TestCase):
         invalid_key_condition = (
             Key("sk").eq("search_testModel_name")
             & Key("data").eq("test1")
-            & Key("data").begins_with("test")
+            & Key("data").begins_with("test")  # Second condition on 'data'
         )
 
         with self.assertRaises(InvalidParameterError):
@@ -45,3 +56,7 @@ class TestDuplicateKeyCondition(unittest.TestCase):
                 KeyConditionExpression=invalid_key_condition,
                 IndexName="DataSearchIndex",
             )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_key_condition_util.py
+++ b/tests/test_key_condition_util.py
@@ -1,7 +1,8 @@
+"""Tests for KeyConditionExpression validation (GitHub issue #967)."""
+
 import unittest
 
 from boto3.dynamodb.conditions import Key
-
 from ddb_single import utils_botos as util_b
 from ddb_single.error import InvalidParameterError
 from ddb_single.key_condition_util import (
@@ -14,38 +15,50 @@ from ddb_single.table import SearchExpression, Table, _coerce_search_expression_
 class TestKeyConditionUtil(unittest.TestCase):
     def test_iter_single_partition_and_sort(self):
         kce = Key("sk").eq("search_user_name") & Key("data").eq("x")
-        self.assertEqual(
-            sorted(iter_key_attributes_used_in_key_condition(kce)), ["data", "sk"]
-        )
+        self.assertEqual(sorted(iter_key_attributes_used_in_key_condition(kce)), ["data", "sk"])
 
-    def test_iter_detects_duplicate_keys(self):
-        kce = Key("sk").eq("a") & Key("data").eq("x") & Key("sk").eq("b")
+    def test_iter_detects_duplicate_sk_in_flat_and(self):
+        kce = Key("sk").eq("a") & Key("data").eq("x") & Key("sk").eq("b") & Key("data").eq("y")
         names = list(iter_key_attributes_used_in_key_condition(kce))
         self.assertEqual(names.count("sk"), 2)
-        self.assertEqual(names.count("data"), 1)
+        self.assertEqual(names.count("data"), 2)
 
     def test_validate_accepts_valid_gsi_key(self):
         kce = Key("sk").eq("search_rocket_name") & Key("data").eq("falcon")
         validate_single_condition_per_key(kce)
 
     def test_validate_accepts_lte_gte_boto3_class_names(self):
+        """boto3 uses LessThanEquals / GreaterThanEquals, not *OrEqualTo."""
         kce = Key("sk").eq("search_user_age") & Key("data-n").lte(15)
         validate_single_condition_per_key(kce)
-        kce = Key("sk").eq("search_user_age") & Key("data-n").gte(10)
-        validate_single_condition_per_key(kce)
+        kce2 = Key("sk").eq("search_user_age") & Key("data-n").gte(10)
+        validate_single_condition_per_key(kce2)
 
     def test_validate_rejects_duplicate_data(self):
-        kce = Key("sk").eq("search_model_name") & Key("data").eq("v") & Key("data").eq("w")
+        kce = Key("sk").eq("search_model_name") & Key("data").eq("v") & Key("data").eq("v")
         with self.assertRaises(InvalidParameterError) as ctx:
             validate_single_condition_per_key(kce)
         self.assertIn("data", str(ctx.exception))
+
+    def test_validate_rejects_duplicate_sk(self):
+        kce = Key("sk").eq("rocket_item") & Key("sk").eq("search_rocket_name") & Key("data").eq("x")
+        with self.assertRaises(InvalidParameterError) as ctx:
+            validate_single_condition_per_key(kce)
+        self.assertIn("sk", str(ctx.exception))
+
+    def test_iter_rejects_composite_without_values(self):
+        bad = type("And", (), {})()
+        with self.assertRaises(InvalidParameterError) as ctx:
+            list(iter_key_attributes_used_in_key_condition(bad))
+        self.assertIn("missing _values", str(ctx.exception).lower())
 
     def test_iter_rejects_unknown_node_type(self):
         class UnknownCondition:
             pass
 
-        with self.assertRaises(InvalidParameterError):
+        with self.assertRaises(InvalidParameterError) as ctx:
             list(iter_key_attributes_used_in_key_condition(UnknownCondition()))
+        self.assertIn("unsupported", str(ctx.exception).lower())
 
     def test_coerce_filter_status_string_staged(self):
         ex = SearchExpression(FilterStatus="staged")
@@ -58,7 +71,8 @@ class TestKeyConditionUtil(unittest.TestCase):
         self.assertIs(ex.FilterStatus, util_b.FilterStatus.FILTER)
 
     def test_search_simple_path_rejects_gsi_shape_on_search_status(self):
-        table = Table(
+        """SEARCH expressions must only add primary-key predicates (issue #967 merge bug)."""
+        t = Table(
             table_name="t",
             endpoint_url="http://localhost:8000",
             region_name="us-west-2",
@@ -67,9 +81,8 @@ class TestKeyConditionUtil(unittest.TestCase):
         )
         bad = SearchExpression(
             FilterStatus=util_b.FilterStatus.SEARCH,
-            KeyConditionExpression=Key("sk").eq("search_user_name")
-            & Key("data").eq("v"),
+            KeyConditionExpression=Key("sk").eq("search_user_name") & Key("data").eq("v"),
         )
         with self.assertRaises(InvalidParameterError) as ctx:
-            table.search("user", bad)
+            t.search("user", bad)
         self.assertIn("primary key", str(ctx.exception).lower())

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,12 +1,12 @@
-import unittest
-from unittest.mock import patch, MagicMock
-from ddb_single.table import FieldType, Table
-from ddb_single.model import BaseModel, DBField
-from ddb_single.query import Query
-from ddb_single.error import ValidationError
-
 import datetime
 import logging
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ddb_single.error import ValidationError
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import FieldType, Table
 
 logging.basicConfig(level=logging.INFO)
 
@@ -27,7 +27,6 @@ class User(BaseModel):
     name_ignore_case = DBField(search_key=True, ignore_case=True)
     email = DBField(search_key=True)
     age = DBField(type=FieldType.NUMBER, search_key=True)
-    description = DBField()
     config = DBField(type=FieldType.MAP)
     tag_list = DBField(type=FieldType.LIST)
     description = DBField(search_key=True)
@@ -93,9 +92,7 @@ class TestCRUD(unittest.TestCase):
                 config={"a": 1, "b": 2},
             )
             query.model(test1).create()
-        res = query.model(User).search(
-            User.name_ignore_case.eq("Test Validation Error")
-        )
+        res = query.model(User).search(User.name_ignore_case.eq("Test Validation Error"))
         self.assertEqual(len(res), 0)
 
     def test_02_0_search(self):
@@ -104,52 +101,38 @@ class TestCRUD(unittest.TestCase):
         self.assertEqual(res[0]["name"], "test")
 
         # 存在しないデータを検索
-        res = query.model(User).search(
-            User.name.eq("test"), User.name_ignore_case.eq("Test3")
-        )
+        res = query.model(User).search(User.name.eq("test"), User.name_ignore_case.eq("Test3"))
         self.assertEqual(len(res), 0)
 
     def test_02_0_search_mult(self):
         """Search by multiple conditions [staged + filter]"""
-        res = query.model(User).search(
-            User.description.contains("test"), User.created_at.gte("2023-10-02")
-        )
+        res = query.model(User).search(User.description.contains("test"), User.created_at.gte("2023-10-02"))
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "test2")
 
         # 存在しないデータを検索
-        res = query.model(User).search(
-            User.description.contains("test"), User.created_at.gte("2023-10-03")
-        )
+        res = query.model(User).search(User.description.contains("test"), User.created_at.gte("2023-10-03"))
         self.assertEqual(len(res), 0)
 
     def test_02_0_search_mult_filter(self):
         """Search by multiple conditions [filter * 2]"""
-        res = query.model(User).search(
-            User.description.contains("test"), User.created_at.contains("01:00:")
-        )
+        res = query.model(User).search(User.description.contains("test"), User.created_at.contains("01:00:"))
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "test2")
 
         # 存在しないデータを検索
-        res = query.model(User).search(
-            User.description.contains("test"), User.created_at.contains("02:00:")
-        )
+        res = query.model(User).search(User.description.contains("test"), User.created_at.contains("02:00:"))
         self.assertEqual(len(res), 0)
 
     def test_02_1_0_search_by_get_field(self):
         """Search by get_field"""
-        res = query.model(User).search(
-            User(__skip_validation__=True).get_field("name").eq("test")
-        )
+        res = query.model(User).search(User(__skip_validation__=True).get_field("name").eq("test"))
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0]["name"], "test")
 
     def test_02_1_1_search_by_get_field_not_found(self):
         """Search by get_field: not found"""
-        res = query.model(User).search(
-            User(__skip_validation__=True).get_field("name").eq("Test")
-        )
+        res = query.model(User).search(User(__skip_validation__=True).get_field("name").eq("Test"))
         self.assertEqual(len(res), 0)
 
     def test_02_2_get_by_unique(self):

--- a/tests/test_query_unique_doubled.py
+++ b/tests/test_query_unique_doubled.py
@@ -1,16 +1,15 @@
-import unittest
-from ddb_single.table import Table
-from ddb_single.model import BaseModel, DBField
-from ddb_single.query import Query
-
 import datetime
 import logging
+import unittest
+
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import Table
 
 logging.basicConfig(level=logging.DEBUG)
 
 table = Table(
-    table_name="query_unique_doubled_test_"
-    + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    table_name="query_unique_doubled_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
     endpoint_url="http://localhost:8000",
     region_name="us-west-2",
     aws_access_key_id="fakeMyKeyId",

--- a/tests/test_query_unique_regression.py
+++ b/tests/test_query_unique_regression.py
@@ -5,10 +5,8 @@ from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
 from ddb_single.table import Table
 
-
 table = Table(
-    table_name="query_unique_regression_"
-    + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    table_name="query_unique_regression_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
     endpoint_url="http://localhost:8000",
     region_name="us-west-2",
     aws_access_key_id="fakeMyKeyId",

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -1,12 +1,11 @@
-import unittest
-
-from ddb_single.table import FieldType, Table
-from ddb_single.model import BaseModel, DBField
-from ddb_single.query import Query
-from ddb_single.error import NotFoundError
-
 import datetime
 import logging
+import unittest
+
+from ddb_single.error import NotFoundError
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import FieldType, Table
 
 logging.basicConfig(level=logging.INFO)
 
@@ -29,12 +28,29 @@ class User(BaseModel):
     description = DBField()
 
 
+class Image(BaseModel):
+    __table__ = table
+    __model_name__ = "image"
+    unique = DBField(unique_key=True)
+    title = DBField(search_key=True)
+
+
+class Slide(BaseModel):
+    __table__ = table
+    __model_name__ = "slide"
+    unique = DBField(unique_key=True)
+    name = DBField(search_key=True)
+    user = DBField(relation=User, search_key=True)
+    pdf = DBField(relation=Image, search_key=True)
+    markdown = DBField(relation=Image, search_key=True)
+
+
 class BlogPost(BaseModel):
     __model_name__ = "blogpost"
     __table__ = table
     title = DBField(unique_key=True)
     content = DBField(search_key=True)
-    author = DBField(reletion=User)
+    author = DBField(relation=User)
 
 
 class Comment(BaseModel):
@@ -42,7 +58,7 @@ class Comment(BaseModel):
     __table__ = table
     title = DBField(unique_key=True)
     content = DBField(search_key=True)
-    author = DBField(reletion=User, relation_raise_if_not_found=True)
+    author = DBField(relation=User, relation_raise_if_not_found=True)
 
 
 print("table_name:", table.__table_name__)
@@ -149,10 +165,62 @@ class TestRelation(unittest.TestCase):
 
         # Blo
         with self.assertRaises(NotFoundError):
-            comment = Comment(
-                unique_key="test", content="test", author="user_not_exist"
-            )
+            comment = Comment(unique_key="test", content="test", author="user_not_exist")
             query.model(comment).update()
+
+    def test_05_multiple_relations(self):
+        """複数の関連フィールドを持つモデルのテスト - Slideモデルのような複雑なケース"""
+
+        # Create related items
+        user = User(name="slide_user", age=25)
+        query.model(user).create()
+
+        pdf_image = Image(unique="pdf-image-1", title="PDF Image")
+        query.model(pdf_image).create()
+
+        markdown_image = Image(unique="markdown-image-1", title="Markdown Image")
+        query.model(markdown_image).create()
+
+        # Create slide with multiple relations
+        slide = Slide(
+            unique="test-slide-1",
+            name="Test Slide",
+            user=user,
+            pdf=pdf_image,
+            markdown=markdown_image,
+        )
+        query.model(slide).create()
+
+        # Verify slide was created
+        res = query.model(Slide).get(slide.data["pk"])
+        self.assertIsNotNone(res)
+        self.assertEqual(res["unique"], "test-slide-1")
+        self.assertEqual(res["user"], "slide_user")
+        self.assertEqual(res["pdf"], "pdf-image-1")
+        self.assertEqual(res["markdown"], "markdown-image-1")
+
+        # Verify relations were created - User relation
+        user_relations = query.model(slide).get_relation(model=User)
+        self.assertEqual(len(user_relations), 1, "Should have 1 User relation")
+        self.assertEqual(user_relations[0]["name"], "slide_user")
+
+        # Verify relations were created - Image relations
+        image_relations = query.model(slide).get_relation(model=Image)
+        self.assertEqual(len(image_relations), 2, "Should have 2 Image relations (pdf + markdown)")
+
+        # Verify we can find the slide from the user
+        user_refs = query.model(user).get_reference(model=Slide)
+        self.assertEqual(len(user_refs), 1, "User should reference 1 Slide")
+        self.assertEqual(user_refs[0]["unique"], "test-slide-1")
+
+        # Verify we can find the slide from the images
+        pdf_refs = query.model(pdf_image).get_reference(model=Slide)
+        self.assertEqual(len(pdf_refs), 1, "PDF Image should reference 1 Slide")
+        self.assertEqual(pdf_refs[0]["unique"], "test-slide-1")
+
+        markdown_refs = query.model(markdown_image).get_reference(model=Slide)
+        self.assertEqual(len(markdown_refs), 1, "Markdown Image should reference 1 Slide")
+        self.assertEqual(markdown_refs[0]["unique"], "test-slide-1")
 
 
 if __name__ == "__main__":

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,11 +1,10 @@
-import unittest
-
-from ddb_single.table import FieldType, Table
-from ddb_single.model import BaseModel, DBField
-from ddb_single.query import Query
-
 import datetime
 import logging
+import unittest
+
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import FieldType, Table
 
 logging.basicConfig(level=logging.INFO)
 
@@ -115,9 +114,7 @@ class TestSearch(unittest.TestCase):
         self.assertIn(res[0]["name"], ["test1", "test2", "test3", "123"])
 
     def test_pk_only(self):
-        res = query.model(User).search(
-            User().get_field("name").eq("test3"), pk_only=True
-        )
+        res = query.model(User).search(User().get_field("name").eq("test3"), pk_only=True)
         self.assertEqual(len(res), 1)
         self.assertIsInstance(res[0], str)
 
@@ -127,11 +124,37 @@ class TestSearch(unittest.TestCase):
         self.assertIsInstance(res[0], str)
 
     def test_empty(self):
-        with self.assertNoLogs(
-            logger=logging.getLogger("ddb_single.table"), level=logging.ERROR
-        ):
+        with self.assertNoLogs(logger=logging.getLogger("ddb_single.table"), level=logging.ERROR):
             res = query.model(User).search(User.name.eq(""))
             self.assertEqual(len(res), 0)
+
+    def test_combined_begins_and_not_equal(self):
+        """Test combining BEGINS and N_EQ filters (AND condition)"""
+        res = query.model(User).search(User.name.begins_with("test"), User.name.ne("test1"))
+        self.assertEqual(len(res), 2)
+        names = [r["name"] for r in res]
+        self.assertIn("test2", names)
+        self.assertIn("test3", names)
+        self.assertNotIn("test1", names)
+
+    def test_combined_filters_with_description(self):
+        """Test combining search_key field and non-search_key field filters"""
+        test1 = User(name="special1", age=30, description="Special item - apple")
+        query.model(test1).create()
+        test2 = User(name="special2", age=31, description="Special item - banana")
+        query.model(test2).create()
+
+        try:
+            res = query.model(User).search(
+                User.name.begins_with("special"), User.description.ne("Special item - apple")
+            )
+            self.assertEqual(len(res), 1)
+            self.assertEqual(res[0]["name"], "special2")
+            self.assertEqual(res[0]["description"], "Special item - banana")
+        finally:
+            # Clean up created items to avoid affecting other tests
+            query.model(test1).delete()
+            query.model(test2).delete()
 
 
 if __name__ == "__main__":

--- a/tests/test_search_fallback_on_validation_exception.py
+++ b/tests/test_search_fallback_on_validation_exception.py
@@ -1,0 +1,214 @@
+import unittest
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+from ddb_single.error import InvalidParameterError
+from ddb_single.model import BaseModel, DBField
+from ddb_single.table import Table
+from ddb_single.utils_botos import FilterStatus
+
+
+def _validation_exception(message: str) -> ClientError:
+    return ClientError(
+        error_response={
+            "Error": {
+                "Code": "ValidationException",
+                "Message": message,
+            }
+        },
+        operation_name="Query",
+    )
+
+
+def _client_error(code: str, message: str) -> ClientError:
+    return ClientError(
+        error_response={
+            "Error": {
+                "Code": code,
+                "Message": message,
+            }
+        },
+        operation_name="Query",
+    )
+
+
+class Rocket(BaseModel):
+    __table__ = Table(
+        table_name="dummy",
+        region_name="us-west-2",
+        aws_access_key_id="dummy",
+        aws_secret_access_key="dummy",
+    )
+    __model_name__ = "rocket"
+    name = DBField(unique_key=True, ignore_case=True)
+
+
+class TestSearchFallbackOnValidationException(unittest.TestCase):
+    def test_fallback_to_rangeindex_and_inmemory_filter_on_searchindex_validation_exception(self):
+        table = Rocket.__table__
+        model = Rocket(__skip_validation__=True)
+        expr = model.get_field("name").eq("Long March 5B")
+        self.assertEqual(expr.FilterStatus, FilterStatus.STAGED)
+
+        calls: list[tuple[str, str | None]] = []
+
+        def fake_query(**kwargs):
+            calls.append(("query", kwargs.get("IndexName")))
+            # First attempt: SearchIndex query -> DynamoDB rejects it
+            if kwargs.get("IndexName") == expr.IndexName:
+                # We do not rely on the exact condition tree shape; we only simulate the service behavior.
+                raise _validation_exception("KeyConditionExpressions must only contain one condition per key")
+
+            # Fallback: RangeIndex to list candidate PKs
+            if kwargs.get("IndexName") == table.__range_index_name__:
+                return [
+                    {table.__primary_key__: "rocket_1"},
+                    {table.__primary_key__: "rocket_2"},
+                ]
+            raise AssertionError(f"Unexpected query call: {kwargs}")
+
+        def fake_batch_get_from_pks(pks):
+            calls.append(("batch_get_from_pks", ",".join(pks)))
+            # Candidate items contain mixed-case names; filter should be ignore-case.
+            items = {
+                "rocket_1": {table.__primary_key__: "rocket_1", "name": "Long March 5B"},
+                "rocket_2": {table.__primary_key__: "rocket_2", "name": "Falcon 9"},
+            }
+            return [items[pk] for pk in pks]
+
+        with (
+            patch.object(table, "query", side_effect=fake_query),
+            patch.object(table, "batch_get_from_pks", side_effect=fake_batch_get_from_pks),
+        ):
+            res = table.search(Rocket.__model_name__, expr)
+        self.assertEqual([r[table.__primary_key__] for r in res], ["rocket_1"])
+        self.assertIn(("query", expr.IndexName), calls)
+        self.assertIn(("query", table.__range_index_name__), calls)
+        self.assertEqual(
+            [call for call in calls if call[0] == "batch_get_from_pks"],
+            [
+                ("batch_get_from_pks", "rocket_1,rocket_2"),
+                ("batch_get_from_pks", "rocket_1"),
+            ],
+        )
+
+    def test_fallback_to_rangeindex_on_invalid_parameter_error(self):
+        table = Rocket.__table__
+        model = Rocket(__skip_validation__=True)
+        expr = model.get_field("name").eq("Long March 5B")
+        calls: list[tuple[str, str | None]] = []
+
+        def fake_query(**kwargs):
+            calls.append(("query", kwargs.get("IndexName")))
+            if kwargs.get("IndexName") == expr.IndexName:
+                raise InvalidParameterError("duplicate key condition")
+            if kwargs.get("IndexName") == table.__range_index_name__:
+                return [{table.__primary_key__: "rocket_1"}]
+            raise AssertionError(f"Unexpected query call: {kwargs}")
+
+        def fake_batch_get_from_pks(pks):
+            calls.append(("batch_get_from_pks", ",".join(pks)))
+            return [{table.__primary_key__: "rocket_1", "name": "Long March 5B"}]
+
+        with (
+            patch.object(table, "query", side_effect=fake_query),
+            patch.object(table, "batch_get_from_pks", side_effect=fake_batch_get_from_pks),
+        ):
+            res = table.search(Rocket.__model_name__, expr)
+
+        self.assertEqual([r[table.__primary_key__] for r in res], ["rocket_1"])
+        self.assertIn(("query", expr.IndexName), calls)
+        self.assertIn(("query", table.__range_index_name__), calls)
+
+    def test_non_validation_client_error_is_reraised(self):
+        table = Rocket.__table__
+        model = Rocket(__skip_validation__=True)
+        expr = model.get_field("name").eq("Long March 5B")
+        calls: list[tuple[str, str | None]] = []
+
+        def fake_query(**kwargs):
+            calls.append(("query", kwargs.get("IndexName")))
+            raise _client_error("ProvisionedThroughputExceededException", "rate limited")
+
+        with patch.object(table, "query", side_effect=fake_query), self.assertRaises(ClientError) as context:
+            table.search(Rocket.__model_name__, expr)
+
+        self.assertEqual(
+            context.exception.response["Error"]["Code"],
+            "ProvisionedThroughputExceededException",
+        )
+        self.assertEqual(calls, [("query", expr.IndexName)])
+
+    def test_fallback_returns_empty_without_batch_get_when_rangeindex_has_no_candidates(self):
+        table = Rocket.__table__
+        model = Rocket(__skip_validation__=True)
+        expr = model.get_field("name").eq("Long March 5B")
+        calls: list[tuple[str, str | None]] = []
+
+        def fake_query(**kwargs):
+            calls.append(("query", kwargs.get("IndexName")))
+            if kwargs.get("IndexName") == expr.IndexName:
+                raise _validation_exception("KeyConditionExpressions must only contain one condition per key")
+            if kwargs.get("IndexName") == table.__range_index_name__:
+                return []
+            raise AssertionError(f"Unexpected query call: {kwargs}")
+
+        def fake_batch_get_from_pks(pks):
+            calls.append(("batch_get_from_pks", ",".join(pks)))
+            return []
+
+        with (
+            patch.object(table, "query", side_effect=fake_query),
+            patch.object(table, "batch_get_from_pks", side_effect=fake_batch_get_from_pks),
+        ):
+            res = table.search(Rocket.__model_name__, expr)
+
+        self.assertEqual(res, [])
+        self.assertEqual(
+            calls,
+            [
+                ("query", expr.IndexName),
+                ("query", table.__range_index_name__),
+            ],
+        )
+
+    def test_fallback_with_none_filter_method_skips_intermediate_inmemory_filter(self):
+        table = Rocket.__table__
+        model = Rocket(__skip_validation__=True)
+        expr = model.get_field("name").eq("Long March 5B")
+        expr.FilterMethod = None
+        calls: list[tuple[str, str | None]] = []
+
+        def fake_query(**kwargs):
+            calls.append(("query", kwargs.get("IndexName")))
+            if kwargs.get("IndexName") == expr.IndexName:
+                raise _validation_exception("KeyConditionExpressions must only contain one condition per key")
+            if kwargs.get("IndexName") == table.__range_index_name__:
+                return [
+                    {table.__primary_key__: "rocket_1"},
+                    {table.__primary_key__: "rocket_2"},
+                ]
+            raise AssertionError(f"Unexpected query call: {kwargs}")
+
+        def fake_batch_get_from_pks(pks):
+            calls.append(("batch_get_from_pks", ",".join(pks)))
+            items = {
+                "rocket_1": {table.__primary_key__: "rocket_1", "name": "Long March 5B"},
+                "rocket_2": {table.__primary_key__: "rocket_2", "name": "Falcon 9"},
+            }
+            return [items[pk] for pk in pks]
+
+        with (
+            patch.object(table, "query", side_effect=fake_query),
+            patch.object(table, "batch_get_from_pks", side_effect=fake_batch_get_from_pks),
+        ):
+            res = table.search(Rocket.__model_name__, expr)
+
+        self.assertCountEqual([r[table.__primary_key__] for r in res], ["rocket_1", "rocket_2"])
+        batch_calls = [call for call in calls if call[0] == "batch_get_from_pks"]
+        self.assertEqual(len(batch_calls), 1)
+        self.assertEqual(set(batch_calls[0][1].split(",")), {"rocket_1", "rocket_2"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_search_index_update.py
+++ b/tests/test_search_index_update.py
@@ -2,11 +2,9 @@ import datetime
 import unittest
 
 from boto3.dynamodb.conditions import Key
-
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
 from ddb_single.table import Table
-
 
 table = Table(
     table_name="search_update_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
@@ -33,23 +31,17 @@ class TestSearchIndexUpdate(unittest.TestCase):
         original = SearchableModel(name="user1", search_key="2024-01-01T00:00:00Z")
         query.model(original).create()
 
-        res_before = query.model(SearchableModel).search(
-            SearchableModel.search_key.eq("2024-01-01T00:00:00Z")
-        )
+        res_before = query.model(SearchableModel).search(SearchableModel.search_key.eq("2024-01-01T00:00:00Z"))
         self.assertEqual(len(res_before), 1)
 
         updated = SearchableModel(name="user1", search_key="2024-02-01T00:00:00Z")
         query.model(updated).update()
 
-        res_after = query.model(SearchableModel).search(
-            SearchableModel.search_key.eq("2024-02-01T00:00:00Z")
-        )
+        res_after = query.model(SearchableModel).search(SearchableModel.search_key.eq("2024-02-01T00:00:00Z"))
         self.assertEqual(len(res_after), 1)
         self.assertEqual(res_after[0]["search_key"], "2024-02-01T00:00:00Z")
 
-        old_res = query.model(SearchableModel).search(
-            SearchableModel.search_key.eq("2024-01-01T00:00:00Z")
-        )
+        old_res = query.model(SearchableModel).search(SearchableModel.search_key.eq("2024-01-01T00:00:00Z"))
         self.assertEqual(len(old_res), 0)
 
     def test_search_index_recreated_when_missing_before_update(self):
@@ -57,28 +49,21 @@ class TestSearchIndexUpdate(unittest.TestCase):
         query.model(original).create()
 
         pk_value = original.data[original.__primary_key__]
-        search_sk_prefix = table.search_key_factory(
-            SearchableModel.__model_name__, "search_key"
-        )
+        search_sk_prefix = table.search_key_factory(SearchableModel.__model_name__, "search_key")
         search_items = table.query(
             KeyConditionExpression=(
-                Key(table.__primary_key__).eq(pk_value)
-                & Key(table.__secondary_key__).begins_with(search_sk_prefix)
+                Key(table.__primary_key__).eq(pk_value) & Key(table.__secondary_key__).begins_with(search_sk_prefix)
             )
         )
         table.batch_delete_items(search_items)
 
-        res_missing = query.model(SearchableModel).search(
-            SearchableModel.search_key.eq("2024-01-01T00:00:00Z")
-        )
+        res_missing = query.model(SearchableModel).search(SearchableModel.search_key.eq("2024-01-01T00:00:00Z"))
         self.assertEqual(len(res_missing), 0)
 
         updated = SearchableModel(name="user1", search_key="2024-02-01T00:00:00Z")
         query.model(updated).update()
 
-        res_after = query.model(SearchableModel).search(
-            SearchableModel.search_key.eq("2024-02-01T00:00:00Z")
-        )
+        res_after = query.model(SearchableModel).search(SearchableModel.search_key.eq("2024-02-01T00:00:00Z"))
         self.assertEqual(len(res_after), 1)
         self.assertEqual(res_after[0]["search_key"], "2024-02-01T00:00:00Z")
 

--- a/tests/test_search_key_chunking.py
+++ b/tests/test_search_key_chunking.py
@@ -1,7 +1,7 @@
 import datetime
 import unittest
-from boto3.dynamodb.conditions import Key
 
+from boto3.dynamodb.conditions import Key
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
 from ddb_single.table import FieldType, Table
@@ -46,11 +46,7 @@ class TestSearchKeyChunking(unittest.TestCase):
         self.assertEqual(len(base_items), 1)
         self.assertEqual(len(base_items[0][data_key]), 64)
 
-        chunk_items = [
-            i
-            for i in items
-            if i[self.table.__secondary_key__].startswith(f"{base_sk}#chunk#")
-        ]
+        chunk_items = [i for i in items if i[self.table.__secondary_key__].startswith(f"{base_sk}#chunk#")]
         self.assertGreater(len(chunk_items), 1)
 
         chunk_items = sorted(chunk_items, key=lambda i: i.get("chunk_index", 0))

--- a/tests/test_search_table.py
+++ b/tests/test_search_table.py
@@ -1,12 +1,11 @@
-import unittest
-
-from ddb_single.table import FieldType, Table, Key, Attr, SearchExpression
-from ddb_single.model import BaseModel, DBField
-from ddb_single.query import Query
-import ddb_single.utils_botos as util_b
-
 import datetime
 import logging
+import unittest
+
+import ddb_single.utils_botos as util_b
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import Attr, FieldType, Key, SearchExpression, Table
 
 logging.basicConfig(level=logging.INFO)
 
@@ -58,8 +57,7 @@ class TestSearchTable(unittest.TestCase):
             {
                 "FilterStatus": util_b.FilterStatus.STAGED,
                 "IndexName": table.__search_index__,
-                "KeyConditionExpression": Key("sk").eq("search_user_name")
-                & Key("data").eq("test001"),
+                "KeyConditionExpression": Key("sk").eq("search_user_name") & Key("data").eq("test001"),
             }
         ]
         res = table.search("user", *searchEx)
@@ -77,14 +75,12 @@ class TestSearchTable(unittest.TestCase):
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.STAGED,
                 IndexName=table.__search_index__,
-                KeyConditionExpression=Key("sk").eq("search_user_name")
-                & Key("data").begins_with("test01"),
+                KeyConditionExpression=Key("sk").eq("search_user_name") & Key("data").begins_with("test01"),
             ),
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.STAGED,
                 IndexName=table.__search_num_index__,
-                KeyConditionExpression=Key("sk").eq("search_user_age")
-                & Key("data-n").lte(15),
+                KeyConditionExpression=Key("sk").eq("search_user_age") & Key("data-n").lte(15),
             ),
         ]
         res = table.search("user", *searchEx)
@@ -105,14 +101,12 @@ class TestSearchTable(unittest.TestCase):
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.STAGED,
                 IndexName=table.__search_index__,
-                KeyConditionExpression=Key("sk").eq("search_user_name")
-                & Key("data").begins_with("test01"),
+                KeyConditionExpression=Key("sk").eq("search_user_name") & Key("data").begins_with("test01"),
             ),
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.STAGED,
                 IndexName=table.__search_num_index__,
-                KeyConditionExpression=Key("sk").eq("search_user_age")
-                & Key("data-n").lte(15),
+                KeyConditionExpression=Key("sk").eq("search_user_age") & Key("data-n").lte(15),
             ),
         ]
         res = table.search("user", *searchEx, limit=3)
@@ -133,14 +127,11 @@ class TestSearchTable(unittest.TestCase):
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.STAGED,
                 IndexName=table.__search_index__,
-                KeyConditionExpression=Key("sk").eq("search_user_name")
-                & Key("data").begins_with("test1"),
+                KeyConditionExpression=Key("sk").eq("search_user_name") & Key("data").begins_with("test1"),
             ),
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.FILTER,
-                FilterMethod=util_b.attr_method(
-                    "description", "odd", util_b.QueryType.CONTAINS
-                ),
+                FilterMethod=util_b.attr_method("description", "odd", util_b.QueryType.CONTAINS),
                 FilterExpression=Attr("description").contains("odd"),
             ),
         ]
@@ -161,9 +152,7 @@ class TestSearchTable(unittest.TestCase):
         searchEx = [
             SearchExpression(
                 FilterStatus=util_b.FilterStatus.FILTER,
-                FilterMethod=util_b.attr_method(
-                    "description", "odd", util_b.QueryType.CONTAINS
-                ),
+                FilterMethod=util_b.attr_method("description", "odd", util_b.QueryType.CONTAINS),
                 FilterExpression=Attr("description").contains("odd"),
             ),
         ]

--- a/tests/test_unique_search_validation_exception.py
+++ b/tests/test_unique_search_validation_exception.py
@@ -1,0 +1,106 @@
+"""
+Test to reproduce the ValidationException issue with unique key searches.
+
+This test reproduces the issue where searching by unique key causes:
+"ValidationException: Invalid KeyConditionExpression:
+ KeyConditionExpressions must only contain one condition per key"
+"""
+
+import datetime
+import logging
+import unittest
+
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import FieldType, Table
+
+logging.basicConfig(level=logging.DEBUG)
+
+table = Table(
+    table_name="unique_search_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    endpoint_url="http://localhost:8000",
+    region_name="us-west-2",
+    aws_access_key_id="fakeMyKeyId",
+    aws_secret_access_key="fakeSecretAccessKey",
+)
+table.init()
+
+
+class NewsList(BaseModel):
+    """Model similar to the real NewsList that causes the issue"""
+
+    __table__ = table
+    __model_name__ = "newsList"
+    name = DBField(unique_key=True)
+    news_list = DBField(type=FieldType.LIST)
+
+
+query = Query(table)
+
+print("table_name:", table.__table_name__)
+
+
+class TestUniqueSearchValidationException(unittest.TestCase):
+    """Test case to reproduce the ValidationException issue"""
+
+    def setUp(self):
+        """Set up test data"""
+        # Create a NewsList item with name "youtube-VideoFromSpace"
+        news_list_item = NewsList(name="youtube-VideoFromSpace", news_list=["news1", "news2", "news3"])
+        query.model(news_list_item).create()
+
+    def test_get_by_unique_should_not_throw_validation_exception(self):
+        """
+        Test that searching by unique key does not cause ValidationException.
+
+        This reproduces the issue from:
+        GET /api-v2/q/newsList/u/youtube-VideoFromSpace/
+
+        Expected: Should return the item or None without exceptions
+        Actual (before fix): ClientError with ValidationException is caught
+                            and empty list is returned, logged as error
+        """
+        # This should work without throwing ValidationException
+        result = query.model(NewsList).get_by_unique("youtube-VideoFromSpace")
+
+        # Should return the item, not None
+        self.assertIsNotNone(result, "get_by_unique should return the item, not None")
+        self.assertEqual(result["name"], "youtube-VideoFromSpace")
+        self.assertEqual(result["news_list"], ["news1", "news2", "news3"])
+
+    def test_search_by_unique_key_eq(self):
+        """
+        Test searching by unique key using eq() directly.
+
+        This is what happens internally in get_by_unique().
+        """
+        # This is what get_by_unique does internally
+        result = query.model(NewsList).search(NewsList.name.eq("youtube-VideoFromSpace"))
+
+        # Should return the item in a list
+        self.assertEqual(len(result), 1, "search should return exactly one item")
+        self.assertEqual(result[0]["name"], "youtube-VideoFromSpace")
+        self.assertEqual(result[0]["news_list"], ["news1", "news2", "news3"])
+
+    def test_multiple_unique_searches(self):
+        """Test multiple unique key searches to ensure consistency"""
+        # Create more items
+        query.model(NewsList(name="test-item-1", news_list=["a"])).create()
+        query.model(NewsList(name="test-item-2", news_list=["b"])).create()
+
+        # Search for each one
+        result1 = query.model(NewsList).get_by_unique("youtube-VideoFromSpace")
+        result2 = query.model(NewsList).get_by_unique("test-item-1")
+        result3 = query.model(NewsList).get_by_unique("test-item-2")
+
+        self.assertIsNotNone(result1)
+        self.assertIsNotNone(result2)
+        self.assertIsNotNone(result3)
+
+        self.assertEqual(result1["name"], "youtube-VideoFromSpace")
+        self.assertEqual(result2["name"], "test-item-1")
+        self.assertEqual(result3["name"], "test-item-2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,61 +1,61 @@
 import unittest
-from boto3.dynamodb.conditions import Key, Attr
 from decimal import Decimal
-from ddb_single.utils_botos import range_ex, attr_ex, attr_method, is_same_json, json_import, json_export, QueryType
+
+from boto3.dynamodb.conditions import Attr, Key
 from ddb_single.error import InvalidParameterError
+from ddb_single.utils_botos import QueryType, attr_ex, attr_method, is_same_json, json_export, json_import, range_ex
 
 
 class TestUtilsBotos(unittest.TestCase):
-
     def test_range_ex(self):
         # Equal mode
-        res = range_ex('test', 'value', QueryType.EQ)
-        self.assertEqual(res, Key('test').eq('value'))
+        res = range_ex("test", "value", QueryType.EQ)
+        self.assertEqual(res, Key("test").eq("value"))
 
         # Between mode
-        res = range_ex('test', [1, 10], QueryType.BETWEEN)
-        self.assertEqual(res, Key('test').between(1, 10))
+        res = range_ex("test", [1, 10], QueryType.BETWEEN)
+        self.assertEqual(res, Key("test").between(1, 10))
 
         # Invalid mode
         with self.assertRaises(InvalidParameterError):
-            range_ex('test', 'value', 'INVALID_MODE')
+            range_ex("test", "value", "INVALID_MODE")
 
     def test_attr_ex(self):
         # Contains mode
-        res = attr_ex('test', 'value', QueryType.CONTAINS)
-        self.assertEqual(res, Attr('test').contains('value'))
+        res = attr_ex("test", "value", QueryType.CONTAINS)
+        self.assertEqual(res, Attr("test").contains("value"))
 
         # In mode
-        res = attr_ex('test', ['value1', 'value2'], QueryType.IN)
-        self.assertEqual(res, Attr('test').is_in(['value1', 'value2']))
+        res = attr_ex("test", ["value1", "value2"], QueryType.IN)
+        self.assertEqual(res, Attr("test").is_in(["value1", "value2"]))
 
         # Invalid mode
         with self.assertRaises(InvalidParameterError):
-            attr_ex('test', 'value', 'INVALID_MODE')
+            attr_ex("test", "value", "INVALID_MODE")
 
     def test_attr_method(self):
         # Equal mode
-        method = attr_method('test', 'value', QueryType.EQ)
-        self.assertTrue(method({'test': 'value'}))
-        self.assertFalse(method({'test': 'wrong_value'}))
+        method = attr_method("test", "value", QueryType.EQ)
+        self.assertTrue(method({"test": "value"}))
+        self.assertFalse(method({"test": "wrong_value"}))
 
         # Between mode
-        method = attr_method('test', [1, 10], QueryType.BETWEEN)
-        self.assertTrue(method({'test': 5}))
-        self.assertFalse(method({'test': 11}))
+        method = attr_method("test", [1, 10], QueryType.BETWEEN)
+        self.assertTrue(method({"test": 5}))
+        self.assertFalse(method({"test": 11}))
 
         # Invalid mode
         with self.assertRaises(InvalidParameterError):
-            attr_method('test', 'value', 'INVALID_MODE')
+            attr_method("test", "value", "INVALID_MODE")
 
     def test_is_same_json(self):
         # Same dictionaries
-        data_1 = {'key1': 'value1', 'key2': 'value2'}
-        data_2 = {'key1': 'value1', 'key2': 'value2'}
+        data_1 = {"key1": "value1", "key2": "value2"}
+        data_2 = {"key1": "value1", "key2": "value2"}
         self.assertTrue(is_same_json(data_1, data_2))
 
         # Different dictionaries
-        data_3 = {'key1': 'value1', 'key2': 'different_value'}
+        data_3 = {"key1": "value1", "key2": "different_value"}
         self.assertFalse(is_same_json(data_1, data_3))
 
         # None comparison
@@ -64,34 +64,22 @@ class TestUtilsBotos(unittest.TestCase):
         self.assertFalse(is_same_json(None, data_1))
 
         # Different types
-        self.assertFalse(is_same_json({'key': 'value'}, ['key', 'value']))
+        self.assertFalse(is_same_json({"key": "value"}, ["key", "value"]))
 
     def test_json_import(self):
-        data = {
-            'key1': 1.23,
-            'key2': [2.34, 3.45],
-            'key3': {'key4': 4.56}
-        }
+        data = {"key1": 1.23, "key2": [2.34, 3.45], "key3": {"key4": 4.56}}
         expected = {
-            'key1': Decimal('1.23'),
-            'key2': [Decimal('2.34'), Decimal('3.45')],
-            'key3': {'key4': Decimal('4.56')}
+            "key1": Decimal("1.23"),
+            "key2": [Decimal("2.34"), Decimal("3.45")],
+            "key3": {"key4": Decimal("4.56")},
         }
         self.assertEqual(json_import(data), expected)
 
     def test_json_export(self):
-        data = {
-            'key1': Decimal('1.23'),
-            'key2': [Decimal('2.34'), Decimal('3.45')],
-            'key3': {'key4': Decimal('4.56')}
-        }
-        expected = {
-            'key1': 1.23,
-            'key2': [2.34, 3.45],
-            'key3': {'key4': 4.56}
-        }
+        data = {"key1": Decimal("1.23"), "key2": [Decimal("2.34"), Decimal("3.45")], "key3": {"key4": Decimal("4.56")}}
+        expected = {"key1": 1.23, "key2": [2.34, 3.45], "key3": {"key4": 4.56}}
         self.assertEqual(json_export(data), expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validation_exception_handling.py
+++ b/tests/test_validation_exception_handling.py
@@ -1,14 +1,26 @@
+"""
+Test that ValidationException is properly re-raised instead of being silently caught.
+"""
+
+import logging
 import unittest
 from unittest.mock import MagicMock
 
-from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
-
 from ddb_single.table import Table
+
+logging.basicConfig(level=logging.INFO)
 
 
 class TestValidationExceptionHandling(unittest.TestCase):
+    """Test that ValidationException is properly handled"""
+
     def test_query_validation_exception_is_reraised(self):
+        """
+        Test that when a ValidationException occurs in query(),
+        it is re-raised instead of being caught and returning empty list.
+        """
+        # Create a table without actually connecting to DynamoDB
         table = Table(
             table_name="test_table",
             endpoint_url="http://localhost:8000",
@@ -16,7 +28,11 @@ class TestValidationExceptionHandling(unittest.TestCase):
             aws_access_key_id="fakeMyKeyId",
             aws_secret_access_key="fakeSecretAccessKey",
         )
+
+        # Create a mock table
         mock_boto_table = MagicMock()
+
+        # Create a mock ValidationException response
         error_response = {
             "Error": {
                 "Code": "ValidationException",
@@ -25,16 +41,23 @@ class TestValidationExceptionHandling(unittest.TestCase):
             "ResponseMetadata": {"RequestId": "test-request-id"},
         }
         mock_boto_table.query.side_effect = ClientError(error_response, "Query")
+
+        # Set the mock table directly (bypassing init())
         table.__table__ = mock_boto_table
 
+        # The ValidationException should be re-raised, not caught
         with self.assertRaises(ClientError) as context:
-            table.query(KeyConditionExpression=Key("pk").eq("x"))
+            table.query()
 
-        self.assertEqual(
-            context.exception.response["Error"]["Code"], "ValidationException"
-        )
+        # Verify it's a ValidationException
+        self.assertEqual(context.exception.response["Error"]["Code"], "ValidationException")
 
     def test_query_other_client_errors_return_empty_list(self):
+        """
+        Test that other ClientErrors (not ValidationException)
+        still return empty list as before.
+        """
+        # Create a table without actually connecting to DynamoDB
         table = Table(
             table_name="test_table",
             endpoint_url="http://localhost:8000",
@@ -42,7 +65,11 @@ class TestValidationExceptionHandling(unittest.TestCase):
             aws_access_key_id="fakeMyKeyId",
             aws_secret_access_key="fakeSecretAccessKey",
         )
+
+        # Create a mock table
         mock_boto_table = MagicMock()
+
+        # Create a mock ProvisionedThroughputExceededException
         error_response = {
             "Error": {
                 "Code": "ProvisionedThroughputExceededException",
@@ -51,12 +78,19 @@ class TestValidationExceptionHandling(unittest.TestCase):
             "ResponseMetadata": {"RequestId": "test-request-id"},
         }
         mock_boto_table.query.side_effect = ClientError(error_response, "Query")
+
+        # Set the mock table directly (bypassing init())
         table.__table__ = mock_boto_table
 
-        result = table.query(KeyConditionExpression=Key("pk").eq("x"))
+        # Other errors should still return empty list
+        result = table.query()
         self.assertEqual(result, [])
 
     def test_scan_validation_exception_is_reraised(self):
+        """
+        Test that ValidationException in scan() is also re-raised.
+        """
+        # Create a table without actually connecting to DynamoDB
         table = Table(
             table_name="test_table",
             endpoint_url="http://localhost:8000",
@@ -64,20 +98,26 @@ class TestValidationExceptionHandling(unittest.TestCase):
             aws_access_key_id="fakeMyKeyId",
             aws_secret_access_key="fakeSecretAccessKey",
         )
+
+        # Create a mock table
         mock_boto_table = MagicMock()
+
         error_response = {
-            "Error": {
-                "Code": "ValidationException",
-                "Message": "Invalid scan parameters",
-            },
+            "Error": {"Code": "ValidationException", "Message": "Invalid scan parameters"},
             "ResponseMetadata": {"RequestId": "test-request-id"},
         }
         mock_boto_table.scan.side_effect = ClientError(error_response, "Scan")
+
+        # Set the mock table directly (bypassing init())
         table.__table__ = mock_boto_table
 
+        # The ValidationException should be re-raised
         with self.assertRaises(ClientError) as context:
             table.scan()
 
-        self.assertEqual(
-            context.exception.response["Error"]["Code"], "ValidationException"
-        )
+        # Verify it's a ValidationException
+        self.assertEqual(context.exception.response["Error"]["Code"], "ValidationException")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

検索の堅牢性向上、フィールド定義APIの綴り修正（後方互換維持）、および複数の安全性・不具合修正をまとめて取り込みます。

## 変更点

### API
- `DBField` の綴り違い引数 `reletion` / `reletion_by_unique` を正しい `relation` / `relation_by_unique` にリネーム。**旧引数も引き続き受け付け**、`DeprecationWarning` を出したうえで新引数にマッピングします（後方互換）。`describe()` の出力キーも `relation_by_unique` になります。

### 不具合修正
- `DBField` からインスタンス共有の `self.value` 状態を廃止。`validate()` / `_setup_relation()` / `search_item()` は値を明示的に受け取るようになり、複数フィールドインスタンス間で値が混ざる問題を防止します。
- `Query._field2relation_items`: primary key で関連付けする際、取得したアイテム dict ではなく PK 自体を格納するよう修正。
- `utils_botos.attr_method`: `BEGINS_WITH` / `CONTAINS` を None セーフ化（値が未設定でも例外にならない）。

### 検索の堅牢性
- `Table.search`: SearchIndex クエリが `ValidationException`（"KeyConditionExpressions must only contain one condition per key"）になる環境向けに、RangeIndex でモデル候補を取得し in-memory フィルタへフォールバックする経路を追加。
- フォールバックの in-memory フィルタでも `ignore_case` を正しく反映。
- 検索結果が空の場合の早期リターンとログの整備。

### その他
- `Table`: 環境変数 `DYNAMODB_ENDPOINT_URL` によるエンドポイント上書きに対応。
- パッケージ `__init__`: import 失敗は `ImportError` のみ握り潰し、それ以外はログ出力のうえ送出。
- CLI `apply_model_change_records`: import 前にモジュールパスを検証（不正なパスの import を防止）。

### テスト
- 検索インデックスのフォールバック、ユニーク検索時の `ValidationException` ハンドリング、`reletion` 後方互換エイリアスのテストを追加。

## 動作確認
- `pytest`: 全パス（114 passed, 15 subtests）
- `flake8 .`: クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `__VERSION__` を追加しました。
  * 関連設定で、正しい引数名（`relation*`）指定に対応し、関連の取得・表示が安定しました。
* **Bug Fixes**
  * CLI のモジュールパス検証を強化し、不正形式は明確に拒否します。
  * エラーメッセージ表記ゆれと `NotFoundError` の出力を改善しました。
  * 検索時のバリデーション例外などでのフォールバック/挙動を整理しました。
* **Tests**
  * CLI・検索・関連・エラー系の回帰/例外テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->