### PR TITLE
fix: validate set-type fields element-wise instead of str() on the collection

### DIFF
--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -173,9 +173,10 @@ class DBField:
         if self.is_list():
             # LIST fields require an actual list; set fields also accept other collections.
             allowed_types = list if self.type == FieldType.LIST else (list, set, tuple, frozenset)
+            expected = "list" if self.type == FieldType.LIST else "collection (list, set, tuple, or frozenset)"
             if not isinstance(value, allowed_types):
                 raise ValidationError(
-                    f"{field_name} must be a list: {self.type} != {type(value)}, input={str(value)[:100]}"
+                    f"{field_name} must be a {expected}: {self.type} != {type(value)}, input={str(value)[:100]}"
                 )
             try:
                 if self.type == FieldType.LIST:
@@ -190,7 +191,7 @@ class DBField:
             except Exception as e:
                 logger.info("Failed to validate", exc_info=e)
                 raise ValidationError(
-                    f"{field_name} must be a valid list: {self.type} != {type(value)}, input={str(value)[:100]}"
+                    f"{field_name} must be a valid {expected}: {self.type} != {type(value)}, input={str(value)[:100]}"
                 )
         else:
             try:

--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -171,7 +171,9 @@ class DBField:
     def _validate_value(self, value):
         field_name = getattr(self, "name", "DBField")
         if self.is_list():
-            if not isinstance(value, list):
+            # LIST fields require an actual list; set fields also accept other collections.
+            allowed_types = list if self.type == FieldType.LIST else (list, set, tuple, frozenset)
+            if not isinstance(value, allowed_types):
                 raise ValidationError(
                     f"{field_name} must be a list: {self.type} != {type(value)}, input={str(value)[:100]}"
                 )
@@ -179,11 +181,11 @@ class DBField:
                 if self.type == FieldType.LIST:
                     return value
                 elif self.type == FieldType.STRING_SET:
-                    return set(value)
+                    return {str(v) for v in value}
                 elif self.type == FieldType.NUMBER_SET:
-                    return set(map(Decimal, str(value)))
+                    return {Decimal(str(v)) for v in value}
                 elif self.type == FieldType.BINARY_SET:
-                    return set(map(bytes, str(value)))
+                    return {v.encode("utf-8") if isinstance(v, str) else bytes(v) for v in value}
                 return value
             except Exception as e:
                 logger.info("Failed to validate", exc_info=e)

--- a/tests/test_dbfield.py
+++ b/tests/test_dbfield.py
@@ -66,6 +66,39 @@ class TestDBFieldValidation(unittest.TestCase):
         with self.assertRaises(ValidationError):
             field.validate(["not", "a", "string"])
 
+    def test_string_set_field_valid(self):
+        field = DBField(type=FieldType.STRING_SET)
+        # Each element is converted to str and the result is a set.
+        self.assertEqual(field.validate(["a", "b", "a"]), {"a", "b"})
+        self.assertEqual(field.validate({"x", "y"}), {"x", "y"})
+        self.assertEqual(field.validate([1, 2]), {"1", "2"})
+
+    def test_number_set_field_valid(self):
+        field = DBField(type=FieldType.NUMBER_SET)
+        # Regression for issue #116: a list of numbers used to be str()-ed and
+        # converted character-by-character, so [1, 2] always failed.
+        self.assertEqual(field.validate([1, 2]), {Decimal("1"), Decimal("2")})
+        self.assertEqual(field.validate([1.5, "2.5"]), {Decimal("1.5"), Decimal("2.5")})
+        self.assertEqual(field.validate({3, 4}), {Decimal("3"), Decimal("4")})
+        self.assertEqual(field.validate((5,)), {Decimal("5")})
+
+    def test_number_set_field_invalid_element(self):
+        field = DBField(type=FieldType.NUMBER_SET)
+        with self.assertRaises(ValidationError):
+            field.validate([1, "not a number"])
+
+    def test_binary_set_field_valid(self):
+        field = DBField(type=FieldType.BINARY_SET)
+        # str elements are utf-8 encoded, others go through bytes() like the scalar BINARY type.
+        self.assertEqual(field.validate(["abc", b"def"]), {b"abc", b"def"})
+        self.assertEqual(field.validate([bytearray(b"xy")]), {b"xy"})
+
+    def test_set_field_rejects_non_collection(self):
+        for field_type in (FieldType.STRING_SET, FieldType.NUMBER_SET, FieldType.BINARY_SET):
+            field = DBField(type=field_type)
+            with self.assertRaises(ValidationError):
+                field.validate("not a collection")
+
     def test_default_value_is_validated(self):
         # A default supplied when no value is given must still be type-validated.
         field = DBField(type=FieldType.NUMBER, default=5)

--- a/tests/test_set_types.py
+++ b/tests/test_set_types.py
@@ -1,0 +1,79 @@
+"""Regression tests for issue #116.
+
+NUMBER_SET / BINARY_SET validation used to call ``str()`` on the input list and
+convert it character-by-character (e.g. ``Decimal("[")``), making those field
+types unusable. These tests verify that set-type fields validate element-wise
+and round-trip through DynamoDB Local.
+"""
+
+import datetime
+import logging
+import unittest
+from decimal import Decimal
+
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import FieldType, Table
+
+logging.basicConfig(level=logging.INFO)
+
+table = Table(
+    table_name="set_types_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    endpoint_url="http://localhost:8000",
+    region_name="us-west-2",
+    aws_access_key_id="fakeMyKeyId",
+    aws_secret_access_key="fakeSecretAccessKey",
+)
+table.init()
+
+
+class Item(BaseModel):
+    __table__ = table
+    __model_name__ = "set_item"
+    name = DBField(unique_key=True, nullable=False)
+    tags = DBField(type=FieldType.STRING_SET)
+    scores = DBField(type=FieldType.NUMBER_SET)
+    blobs = DBField(type=FieldType.BINARY_SET)
+
+
+query = Query(table)
+
+
+class TestSetTypeRoundTrip(unittest.TestCase):
+    def test_set_fields_round_trip(self):
+        item = Item(
+            name="set_test",
+            tags=["red", "blue", "red"],
+            scores=[1, 2],  # the exact input that used to break NUMBER_SET
+            blobs=["abc", b"def"],
+        )
+        # Validation happens at model construction: element-wise conversion.
+        self.assertEqual(item.data["tags"], {"red", "blue"})
+        self.assertEqual(item.data["scores"], {Decimal("1"), Decimal("2")})
+        self.assertEqual(item.data["blobs"], {b"abc", b"def"})
+
+        query.model(item).create()
+        res = query.model(Item).get(item.data["pk"])
+        self.assertIsNotNone(res)
+        self.assertEqual(set(res["tags"]), {"red", "blue"})
+        self.assertEqual({Decimal(v) for v in res["scores"]}, {Decimal("1"), Decimal("2")})
+        self.assertEqual({bytes(v) for v in res["blobs"]}, {b"abc", b"def"})
+
+    def test_set_input_accepted(self):
+        item = Item(
+            name="set_input_test",
+            tags={"a", "b"},
+            scores={Decimal("3"), Decimal("4.5")},
+        )
+        self.assertEqual(item.data["tags"], {"a", "b"})
+        self.assertEqual(item.data["scores"], {Decimal("3"), Decimal("4.5")})
+
+        query.model(item).create()
+        res = query.model(Item).get(item.data["pk"])
+        self.assertIsNotNone(res)
+        self.assertEqual(set(res["tags"]), {"a", "b"})
+        self.assertEqual({Decimal(v) for v in res["scores"]}, {Decimal("3"), Decimal("4.5")})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
SET 型フィールドのバリデーションバグ修正(`model.py` `DBField._validate_value`)。

**原因**: コレクション全体を `str()` してから 1 文字ずつ変換していた:
- `NUMBER_SET`: `set(map(Decimal, str(value)))` — `str([1, 2])` は `"[1, 2]"` となり `Decimal("[")` で常に `ValidationError`
- `BINARY_SET`: 同様の文字単位バグ
- `STRING_SET`: 要素の `str` 変換が行われない

**修正**: スカラー型の変換規則に合わせた要素単位の変換に変更(`STRING_SET` → `{str(v) ...}`、`NUMBER_SET` → `{Decimal(str(v)) ...}`、`BINARY_SET` → `{encode/bytes ...}`)。`list`/`set`/`tuple`/`frozenset` 入力を受け付け、要素変換失敗は従来どおり `ValidationError`。

## 検証
- `tests/test_dbfield.py` 拡張 + 新規 `tests/test_set_types.py`(DynamoDB Local での SS/NS/BS ラウンドトリップ E2E)
- `uv run pytest -v`: 124 passed, 15 subtests passed
- `ruff check` / `ruff format --check` クリーン

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 文字列・数値・バイナリの集合型で、リストに加えてセットやタプルなどの入力を利用できるようになりました。
  * 集合型の各要素が正しく変換され、重複が自動的に除去されるようになりました。

* **バグ修正**
  * 数値・バイナリ集合が、入力全体ではなく要素単位で正しく処理されるようになりました。
  * 不正な値には適切な入力エラーが表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->