### PR TITLE
fix: exact model-name matching for relation/reference queries

### DIFF
--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -376,6 +376,15 @@ class Table:
         return self.batch_get(keys)
 
     # --- 検索関連 ---
+    def _pk_model_matches(self, pk, model_name):
+        """pk のモデル名が model_name と完全一致するか確認する。
+
+        begins_with によるプレフィックス照合は、モデル名が別モデル名の前方一致に
+        なっている場合 (例: "user" と "user_admin") に衝突するため、
+        取得後にモデル名の完全一致を確認する必要がある。
+        """
+        return self.pk2model(pk) == model_name
+
     def relation(self, pk, model_name="", field_name="", pk_only=False):
         """関連先を検索"""
         logger.debug(f"pk: {pk}, model_name: {model_name}, field_name: {field_name}")
@@ -396,6 +405,10 @@ class Table:
                 ProjectionExpression=self.__secondary_key__,
             )
         pks = [self.rel_key2pk(r[self.__secondary_key__]) for r in res]
+        if model_name:
+            # begins_with はプレフィックス一致のため、モデル名が前方一致する
+            # 別モデル (例: "user" と "user_admin") を除外する
+            pks = [p for p in pks if self._pk_model_matches(p, model_name)]
         if pk_only:
             return pks
         else:
@@ -428,6 +441,10 @@ class Table:
                 ProjectionExpression=self.__primary_key__,
             )
         pks = [r[self.__primary_key__] for r in res]
+        if model_name:
+            # begins_with はプレフィックス一致のため、モデル名が前方一致する
+            # 別モデル (例: "user" と "user_admin") を除外する
+            pks = [p for p in pks if self._pk_model_matches(p, model_name)]
         if pk_only:
             return pks
         else:
@@ -733,6 +750,10 @@ class Table:
             KeyConditionExpression=KeyConditionExpression,
             ProjectionExpression=f"{self.__primary_key__}, {self.__secondary_key__}",
         )
+        if model_name:
+            # begins_with はプレフィックス一致のため、モデル名が前方一致する
+            # 別モデル (例: "user" と "user_admin") の関連を誤削除しない
+            items = [i for i in items if self._pk_model_matches(self.rel_key2pk(i[self.__secondary_key__]), model_name)]
         self.batch_delete_items(items, batch)
 
     def clear_reference(self, pk, model_name="", batch=None):
@@ -745,6 +766,10 @@ class Table:
             IndexName=self.__range_index_name__,
             ProjectionExpression=f"{self.__primary_key__}, {self.__secondary_key__}",
         )
+        if model_name:
+            # begins_with はプレフィックス一致のため、モデル名が前方一致する
+            # 別モデル (例: "user" と "user_admin") の参照を誤削除しない
+            items = [i for i in items if self._pk_model_matches(i[self.__primary_key__], model_name)]
         self.batch_delete_items(items, batch)
 
     # --- ここからテーブル作成 ---

--- a/tests/test_prefix_collision.py
+++ b/tests/test_prefix_collision.py
@@ -1,0 +1,143 @@
+"""Regression tests for issue #117.
+
+``begins_with`` matching on model-name prefixes must not collide between
+models where one model name is a prefix of another
+(e.g. "user" vs "user_admin", "note" vs "note_child").
+"""
+
+import datetime
+import logging
+import unittest
+
+from ddb_single.model import BaseModel, DBField
+from ddb_single.query import Query
+from ddb_single.table import Table
+
+logging.basicConfig(level=logging.INFO)
+
+table = Table(
+    table_name="prefix_col_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    endpoint_url="http://localhost:8000",
+    region_name="us-west-2",
+    aws_access_key_id="fakeMyKeyId",
+    aws_secret_access_key="fakeSecretAccessKey",
+)
+table.init()
+
+
+class User(BaseModel):
+    __table__ = table
+    __model_name__ = "user"
+    name = DBField(unique_key=True)
+
+
+class UserAdmin(BaseModel):
+    __table__ = table
+    __model_name__ = "user_admin"
+    name = DBField(unique_key=True)
+
+
+class Note(BaseModel):
+    __table__ = table
+    __model_name__ = "note"
+    title = DBField(unique_key=True)
+    user = DBField(relation=User)
+    admin = DBField(relation=UserAdmin)
+
+
+class NoteChild(BaseModel):
+    __table__ = table
+    __model_name__ = "note_child"
+    title = DBField(unique_key=True)
+    user = DBField(relation=User)
+
+
+query = Query(table)
+
+
+class TestPrefixCollision(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.user = User(name="alice")
+        query.model(cls.user).create()
+        cls.admin = UserAdmin(name="bob")
+        query.model(cls.admin).create()
+        cls.note = Note(title="note1", user=cls.user, admin=cls.admin)
+        query.model(cls.note).create()
+        cls.note_child = NoteChild(title="child1", user=cls.user)
+        query.model(cls.note_child).create()
+
+    def test_01_relation_no_cross_match(self):
+        """get_relation(model=User) must not return user_admin items"""
+        res = query.model(self.note).get_relation(model=User)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["name"], "alice")
+        self.assertEqual(table.pk2model(res[0]["pk"]), "user")
+
+        res = query.model(self.note).get_relation(model=UserAdmin)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["name"], "bob")
+        self.assertEqual(table.pk2model(res[0]["pk"]), "user_admin")
+
+        # 引数なしの場合は両方返る
+        res = query.model(self.note).get_relation()
+        self.assertEqual(len(res), 2)
+
+    def test_02_reference_no_cross_match(self):
+        """get_reference(model=Note) must not return note_child items"""
+        res = query.model(self.user).get_reference(model=Note)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["title"], "note1")
+        self.assertEqual(table.pk2model(res[0]["pk"]), "note")
+
+        res = query.model(self.user).get_reference(model=NoteChild)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["title"], "child1")
+        self.assertEqual(table.pk2model(res[0]["pk"]), "note_child")
+
+        # フィールド指定の参照検索も同様
+        res = query.model(self.user).get_reference(model=Note, field=Note.user)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["title"], "note1")
+
+        # 引数なしの場合は両方返る
+        res = query.model(self.user).get_reference()
+        self.assertEqual(len(res), 2)
+
+    def test_03_clear_relation_no_cross_delete(self):
+        """clear_relation(model_name="user") must not delete user_admin relations"""
+        note = Note(title="note2", user=self.user, admin=self.admin)
+        query.model(note).create()
+        note_pk = note.data["pk"]
+
+        table.clear_relation(note_pk, model_name="user")
+        # user への関連は削除される
+        res = query.model(note).get_relation(model=User)
+        self.assertEqual(len(res), 0)
+        # user_admin への関連は残る
+        res = query.model(note).get_relation(model=UserAdmin)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["name"], "bob")
+
+    def test_04_clear_reference_no_cross_delete(self):
+        """clear_reference(model_name="note") must not delete note_child references"""
+        user = User(name="carol")
+        query.model(user).create()
+        note = Note(title="note3", user=user)
+        query.model(note).create()
+        note_child = NoteChild(title="child3", user=user)
+        query.model(note_child).create()
+        user_pk = user.data["pk"]
+
+        table.clear_reference(user_pk, model_name="note")
+        # note からの参照は削除される
+        res = query.model(user).get_reference(model=Note)
+        self.assertEqual(len(res), 0)
+        # note_child からの参照は残る
+        res = query.model(user).get_reference(model=NoteChild)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["title"], "child3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prefix_collision.py
+++ b/tests/test_prefix_collision.py
@@ -8,6 +8,7 @@ models where one model name is a prefix of another
 import datetime
 import logging
 import unittest
+import uuid
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
@@ -16,7 +17,7 @@ from ddb_single.table import Table
 logging.basicConfig(level=logging.INFO)
 
 table = Table(
-    table_name="prefix_col_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+    table_name=f"prefix_col_{datetime.datetime.now():%Y%m%d%H%M%S%f}_{uuid.uuid4().hex}",
     endpoint_url="http://localhost:8000",
     region_name="us-west-2",
     aws_access_key_id="fakeMyKeyId",


### PR DESCRIPTION
## 概要
モデル名プレフィックス衝突の修正(`table.py`)。

**原因**: `relation()` / `reference()` / `clear_relation()` / `clear_reference()` が `begins_with` でモデル名を照合するため、モデル `user` のクエリが `user_admin` のアイテムにもマッチ(クロスモデルのデータ漏洩、`clear_*` では他モデルのリレーションアイテムの誤削除)。

**修正**: 区切り文字を足すだけでは不十分(`begins_with("rel_user_")` は `rel_user_admin_<uuid>` にもマッチ)なため、`begins_with` はサーバー側絞り込みとして維持しつつ、新設の `Table._pk_model_matches()`(`pk2model(pk) == model_name` の厳密一致)で後段フィルタする方式を採用。保存済みキー形式は不変で後方互換、カスタム `primary_key_factory` / `primary_key2model` 設定にも対応。

## 検証
- 新規 `tests/test_prefix_collision.py`: `user`/`user_admin`、`note`/`note_child` で `get_relation` / `get_reference` / `clear_relation` / `clear_reference` を検証。修正前のコードで 4 テストすべて失敗(誤削除バグ含む)、修正後は成功することを確認済み
- `uv run pytest -v`: 121 passed, 15 subtests passed
- `ruff check` / `ruff format` クリーン

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * モデル名が似ている関連データでも、指定したモデルのデータだけを正しく取得できるようになりました。
  * 関連・参照の解除時に、別モデルのデータまで誤って削除される問題を防止しました。

* **テスト**
  * モデル名の前方一致によるデータ混入や誤削除を検証する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->