### PR TITLE
fix: propagate non-ValidationException ClientErrors instead of failing open

### DIFF
--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -230,9 +230,12 @@ class Table:
     def _execute_boto_op(self, op, label, **kwargs):
         """boto3 の scan/query を実行し、ページネーションを含めて統一的にエラーハンドリングする。
 
-        成功時はレスポンス(dict)を返す。ValidationException はクエリ自体の問題なので
-        呼び出し側で扱えるよう再送出し、それ以外の ClientError はログ出力のうえ None を返す
-        （= 呼び出し側は空扱いにする）。
+        成功時はレスポンス(dict)を返す。ClientError は詳細をログ出力したうえで必ず再送出する。
+        AccessDenied やスロットリング等を「該当データなし（空結果）」に変換すると、
+        get_by_unique 経由の create/update/delete で重複作成・削除漏れなど
+        データ整合性を破壊し得るため、fail-open にはしない。
+        ValidationException は search-index フォールバック用に呼び出し側
+        (`_query_staged_pks`) が捕捉して処理する。
         """
         try:
             return op(**kwargs)
@@ -256,21 +259,12 @@ class Table:
                 },
                 exc_info=True,
             )
-
-            # ValidationException は「データが無い」ではなくリクエスト構造の問題なので再送出する
-            if error_code == "ValidationException":
-                raise
-
-            # その他のエラーは空扱い（既存挙動）
-            return None
+            raise
 
     def scan(self, **kwargs) -> list[dict]:
         """スキャン"""
         limit = kwargs.get("Limit") or float("inf")
         response = self._execute_boto_op(self.__table__.scan, "Scan", **kwargs)
-        if response is None:
-            return []
-
         if "Items" in response:
             res_data = response["Items"]
             while "LastEvaluatedKey" in response and len(res_data) < limit:
@@ -278,8 +272,6 @@ class Table:
                 response = self._execute_boto_op(
                     self.__table__.scan, "Scan", **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
                 )
-                if response is None:
-                    break
                 res_data += response["Items"]
             return util_b.json_export(res_data)
         return []
@@ -291,9 +283,6 @@ class Table:
         if kce is not None:
             validate_single_condition_per_key(kce)
         response = self._execute_boto_op(self.__table__.query, "Query", **kwargs)
-        if response is None:
-            return []
-
         if "Items" in response:
             # FilterExpression 付き Query は 1 ページ目が 0 件でも LastEvaluatedKey を返す
             # ことがあるため、scan() と同様に LastEvaluatedKey ベースでページを辿る。
@@ -302,8 +291,6 @@ class Table:
                 response = self._execute_boto_op(
                     self.__table__.query, "Query", **kwargs, ExclusiveStartKey=response["LastEvaluatedKey"]
                 )
-                if response is None:
-                    break
                 res_data += response["Items"]
             return util_b.json_export(res_data)
         return []

--- a/tests/test_validation_exception_handling.py
+++ b/tests/test_validation_exception_handling.py
@@ -3,6 +3,7 @@ Test that ValidationException is properly re-raised instead of being silently ca
 """
 
 import logging
+import time
 import unittest
 from unittest.mock import MagicMock
 
@@ -11,6 +12,17 @@ from botocore.exceptions import ClientError
 from ddb_single.table import Table
 
 logging.basicConfig(level=logging.INFO)
+
+
+def _make_table() -> Table:
+    """Build a Table with a unique name (never connects to DynamoDB in these tests)."""
+    return Table(
+        table_name=f"test_{time.time_ns()}",
+        endpoint_url="http://localhost:8000",
+        region_name="us-west-2",
+        aws_access_key_id="fakeMyKeyId",
+        aws_secret_access_key="fakeSecretAccessKey",
+    )
 
 
 class TestValidationExceptionHandling(unittest.TestCase):
@@ -22,13 +34,7 @@ class TestValidationExceptionHandling(unittest.TestCase):
         it is re-raised instead of being caught and returning empty list.
         """
         # Create a table without actually connecting to DynamoDB
-        table = Table(
-            table_name="test_table",
-            endpoint_url="http://localhost:8000",
-            region_name="us-west-2",
-            aws_access_key_id="fakeMyKeyId",
-            aws_secret_access_key="fakeSecretAccessKey",
-        )
+        table = _make_table()
 
         # Create a mock table
         mock_boto_table = MagicMock()
@@ -53,21 +59,28 @@ class TestValidationExceptionHandling(unittest.TestCase):
         # Verify it's a ValidationException
         self.assertEqual(context.exception.response["Error"]["Code"], "ValidationException")
 
-    def _table_with_error(self, operation, error_code, error_message):
-        """Build a Table whose boto3 table raises the given ClientError."""
-        table = Table(
-            table_name="test_table",
-            endpoint_url="http://localhost:8000",
-            region_name="us-west-2",
-            aws_access_key_id="fakeMyKeyId",
-            aws_secret_access_key="fakeSecretAccessKey",
-        )
+    def _table_with_error(self, operation, error_code, error_message, fail_on_second_page=False):
+        """Build a Table whose boto3 table raises the given ClientError.
+
+        With ``fail_on_second_page=True``, the first call returns a page with a
+        ``LastEvaluatedKey`` and the error is raised on the pagination call.
+        """
+        table = _make_table()
         mock_boto_table = MagicMock()
         error_response = {
             "Error": {"Code": error_code, "Message": error_message},
             "ResponseMetadata": {"RequestId": "test-request-id"},
         }
-        getattr(mock_boto_table, operation.lower()).side_effect = ClientError(error_response, operation)
+        error = ClientError(error_response, operation)
+        if fail_on_second_page:
+            first_page = {
+                "Items": [{"pk": "test_item_1", "sk": "test_item"}],
+                "LastEvaluatedKey": {"pk": "test_item_1", "sk": "test_item"},
+            }
+            side_effect = [first_page, error]
+        else:
+            side_effect = error
+        getattr(mock_boto_table, operation.lower()).side_effect = side_effect
         # Set the mock table directly (bypassing init())
         table.__table__ = mock_boto_table
         return table
@@ -117,18 +130,47 @@ class TestValidationExceptionHandling(unittest.TestCase):
 
         self.assertEqual(context.exception.response["Error"]["Code"], "ResourceNotFoundException")
 
+    def test_query_client_error_during_pagination_is_reraised(self):
+        """A ClientError raised while fetching the second page of query() must propagate."""
+        table = self._table_with_error(
+            "Query",
+            "ProvisionedThroughputExceededException",
+            "The level of configured provisioned throughput for the table was exceeded",
+            fail_on_second_page=True,
+        )
+
+        with self.assertRaises(ClientError) as context:
+            table.query()
+
+        self.assertEqual(
+            context.exception.response["Error"]["Code"],
+            "ProvisionedThroughputExceededException",
+        )
+        # Both the first page and the failing pagination call must have been made
+        self.assertEqual(table.__table__.query.call_count, 2)
+
+    def test_scan_client_error_during_pagination_is_reraised(self):
+        """A ClientError raised while fetching the second page of scan() must propagate."""
+        table = self._table_with_error(
+            "Scan",
+            "ResourceNotFoundException",
+            "Requested resource not found",
+            fail_on_second_page=True,
+        )
+
+        with self.assertRaises(ClientError) as context:
+            table.scan()
+
+        self.assertEqual(context.exception.response["Error"]["Code"], "ResourceNotFoundException")
+        # Both the first page and the failing pagination call must have been made
+        self.assertEqual(table.__table__.scan.call_count, 2)
+
     def test_scan_validation_exception_is_reraised(self):
         """
         Test that ValidationException in scan() is also re-raised.
         """
         # Create a table without actually connecting to DynamoDB
-        table = Table(
-            table_name="test_table",
-            endpoint_url="http://localhost:8000",
-            region_name="us-west-2",
-            aws_access_key_id="fakeMyKeyId",
-            aws_secret_access_key="fakeSecretAccessKey",
-        )
+        table = _make_table()
 
         # Create a mock table
         mock_boto_table = MagicMock()

--- a/tests/test_validation_exception_handling.py
+++ b/tests/test_validation_exception_handling.py
@@ -53,12 +53,8 @@ class TestValidationExceptionHandling(unittest.TestCase):
         # Verify it's a ValidationException
         self.assertEqual(context.exception.response["Error"]["Code"], "ValidationException")
 
-    def test_query_other_client_errors_return_empty_list(self):
-        """
-        Test that other ClientErrors (not ValidationException)
-        still return empty list as before.
-        """
-        # Create a table without actually connecting to DynamoDB
+    def _table_with_error(self, operation, error_code, error_message):
+        """Build a Table whose boto3 table raises the given ClientError."""
         table = Table(
             table_name="test_table",
             endpoint_url="http://localhost:8000",
@@ -66,26 +62,60 @@ class TestValidationExceptionHandling(unittest.TestCase):
             aws_access_key_id="fakeMyKeyId",
             aws_secret_access_key="fakeSecretAccessKey",
         )
-
-        # Create a mock table
         mock_boto_table = MagicMock()
-
-        # Create a mock ProvisionedThroughputExceededException
         error_response = {
-            "Error": {
-                "Code": "ProvisionedThroughputExceededException",
-                "Message": "The level of configured provisioned throughput for the table was exceeded",
-            },
+            "Error": {"Code": error_code, "Message": error_message},
             "ResponseMetadata": {"RequestId": "test-request-id"},
         }
-        mock_boto_table.query.side_effect = ClientError(error_response, "Query")
-
+        getattr(mock_boto_table, operation.lower()).side_effect = ClientError(error_response, operation)
         # Set the mock table directly (bypassing init())
         table.__table__ = mock_boto_table
+        return table
 
-        # Other errors should still return empty list
-        result = table.query()
-        self.assertEqual(result, [])
+    def test_query_other_client_errors_are_reraised(self):
+        """
+        Test that other ClientErrors (not ValidationException) propagate
+        instead of being converted into an empty result (fail-open).
+        """
+        table = self._table_with_error(
+            "Query",
+            "ProvisionedThroughputExceededException",
+            "The level of configured provisioned throughput for the table was exceeded",
+        )
+
+        with self.assertRaises(ClientError) as context:
+            table.query()
+
+        self.assertEqual(
+            context.exception.response["Error"]["Code"],
+            "ProvisionedThroughputExceededException",
+        )
+
+    def test_query_access_denied_is_reraised(self):
+        """AccessDeniedException in query() must propagate, not become an empty result."""
+        table = self._table_with_error(
+            "Query",
+            "AccessDeniedException",
+            "User is not authorized to perform: dynamodb:Query",
+        )
+
+        with self.assertRaises(ClientError) as context:
+            table.query()
+
+        self.assertEqual(context.exception.response["Error"]["Code"], "AccessDeniedException")
+
+    def test_scan_other_client_errors_are_reraised(self):
+        """ResourceNotFoundException in scan() must propagate, not become an empty result."""
+        table = self._table_with_error(
+            "Scan",
+            "ResourceNotFoundException",
+            "Requested resource not found",
+        )
+
+        with self.assertRaises(ClientError) as context:
+            table.scan()
+
+        self.assertEqual(context.exception.response["Error"]["Code"], "ResourceNotFoundException")
 
     def test_scan_validation_exception_is_reraised(self):
         """


### PR DESCRIPTION
## 概要
fail-open 設計の修正(`table.py` `_execute_boto_op`)。

従来は `ValidationException` のみ再送出し、それ以外のすべての `ClientError`(`AccessDeniedException`、`ProvisionedThroughputExceededException`、`ResourceNotFoundException` 等)を `None` → 空結果に変換していました。これをログ出力の上すべて再送出するよう変更し、`scan()` / `query()` 内の到達不能になった `response is None` 分岐を削除。

d71384c で導入された意図的な検索インデックスフォールバック(`_query_staged_pks()` が `ValidationException` を捕捉して RangeIndex クエリへフォールバック)は無変更で、`ValidationException` のエンドツーエンドの挙動は完全に維持されます。

## 検証
- fail-open を仕様として固定していたテストを再送出検証に置き換え、`AccessDeniedException` / `ResourceNotFoundException` / `ProvisionedThroughputExceededException` の伝播テストを追加
- 既存の検索フォールバックテスト 5 件は無変更で成功
- `uv run pytest -v`: 119 passed, 15 subtests passed
- `ruff check` / `ruff format --check` クリーン

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * DynamoDB のクエリ・スキャン処理で、アクセス拒否やリソース未検出、スループット超過などのエラーを空の結果として扱わず、呼び出し元へ正しく通知するよう改善しました。
  * 複数ページにわたる検索結果の取得処理を、エラー発生時にも適切に扱えるよう修正しました。

* **テスト**
  * 各種 DynamoDB エラーが正しく再送出されることを検証するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->