### PR TITLE
fix: logging hygiene — narrow deserialize() exception handling and stop logging raw data values

### DIFF
--- a/ddb_single/model.py
+++ b/ddb_single/model.py
@@ -12,6 +12,17 @@ from ddb_single.table import FieldType, SearchExpression, Table
 logger = logging.getLogger(__name__)
 
 
+def _value_summary(value):
+    """実データ値をログ・例外メッセージに含めないための要約 (型と長さのみ)。
+
+    実データ値は PII を含む恐れがあるため、ログ・例外メッセージには出力しない。
+    """
+    try:
+        return f"type={type(value).__name__}, len={len(value)}"
+    except TypeError:
+        return f"type={type(value).__name__}"
+
+
 class DBField:
     """
     DBField is a field of a model. It is used to define the structure of a model.
@@ -176,7 +187,7 @@ class DBField:
             expected = "list" if self.type == FieldType.LIST else "collection (list, set, tuple, or frozenset)"
             if not isinstance(value, allowed_types):
                 raise ValidationError(
-                    f"{field_name} must be a {expected}: {self.type} != {type(value)}, input={str(value)[:100]}"
+                    f"{field_name} must be a {expected}: expected {self.type}, got {_value_summary(value)}"
                 )
             try:
                 if self.type == FieldType.LIST:
@@ -191,13 +202,13 @@ class DBField:
             except Exception as e:
                 logger.info("Failed to validate", exc_info=e)
                 raise ValidationError(
-                    f"{field_name} must be a valid {expected}: {self.type} != {type(value)}, input={str(value)[:100]}"
+                    f"{field_name} must be a valid {expected}: expected {self.type}, got {_value_summary(value)}"
                 )
         else:
             try:
                 if isinstance(value, list):
                     raise ValidationError(
-                        f"{field_name} must not be a list: {self.type} != {type(value)}, input={str(value)[:100]}"
+                        f"{field_name} must not be a list: expected {self.type}, got {_value_summary(value)}"
                     )
                 if self.type == FieldType.STRING:
                     return str(value)
@@ -214,7 +225,7 @@ class DBField:
             except Exception as e:
                 logger.info("Failed to validate", exc_info=e)
                 raise ValidationError(
-                    f"Value {field_name} must be a valid value, {self.type} != {type(value)}, input={str(value)[:100]}"
+                    f"Value {field_name} must be a valid value: expected {self.type}, got {_value_summary(value)}"
                 )
 
     def search_key_factory(self):

--- a/ddb_single/query.py
+++ b/ddb_single/query.py
@@ -94,7 +94,8 @@ class Query:
                 logger.warning(f"get_by_unique: {key} not in {specified_keys} ... skip")
                 continue
             _res = self.search(getattr(self.__model__.__class__, key).eq(value), pk_only=pk_only)
-            logger.debug(f"get_by_unique: {key}={value} result={_res}")
+            # ポリシー上、実データ値 (unique key の値・検索結果) はログに出さない。
+            logger.debug("get_by_unique: key=%s, results=%d", key, len(_res))
             res.extend(_res)
         if res:
             return res[0]
@@ -131,7 +132,8 @@ class Query:
                 logger.warning(f"batch_get_by_unique: {key} not in {specified_keys} ... skip")
                 continue
             _res = self.search(getattr(self.__model__.__class__, key).in_(uniques), pk_only=pk_only)
-            logger.debug(f"batch_get_by_unique: {key} in {uniques} result={_res}")
+            # ポリシー上、実データ値 (unique key の値・検索結果) はログに出さない。
+            logger.debug("batch_get_by_unique: key=%s, uniques_count=%d, results=%d", key, len(uniques), len(_res))
             res.extend(_res)
         return res
 

--- a/ddb_single/table.py
+++ b/ddb_single/table.py
@@ -244,18 +244,16 @@ class Table:
             error_msg = e.response.get("Error", {}).get("Message", "No message")
 
             # 失敗したリクエストの詳細をログに残す
+            # ポリシー上、実データ値 (KeyCondition/Filter 式に含まれる値) はログに出さず、
+            # 式の有無のみを記録する。
             logger.error(
                 f"DynamoDB {label} failed with {error_code}: {error_msg}",
                 extra={
                     "error_code": error_code,
                     "error_message": error_msg,
                     "index_name": kwargs.get("IndexName"),
-                    "key_condition_expression": str(kwargs.get("KeyConditionExpression"))
-                    if kwargs.get("KeyConditionExpression")
-                    else None,
-                    "filter_expression": str(kwargs.get("FilterExpression"))
-                    if kwargs.get("FilterExpression")
-                    else None,
+                    "has_key_condition_expression": kwargs.get("KeyConditionExpression") is not None,
+                    "has_filter_expression": kwargs.get("FilterExpression") is not None,
                 },
                 exc_info=True,
             )

--- a/ddb_single/utils_botos.py
+++ b/ddb_single/utils_botos.py
@@ -1,4 +1,5 @@
 # ddb_single/utils_botos.py
+import logging
 from decimal import Decimal
 
 # クエリ設定のENUM
@@ -8,6 +9,8 @@ from boto3.dynamodb.conditions import Attr, Key
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 
 from ddb_single.error import InvalidParameterError
+
+logger = logging.getLogger(__name__)
 
 
 class QueryType(Enum):
@@ -123,7 +126,15 @@ def deserialize(value):
         if isinstance(v, dict):
             try:
                 result[k] = TypeDeserializer().deserialize(v)
-            except Exception:
+            except (TypeError, AttributeError, KeyError) as err:
+                # DynamoDB 型付き dict でない普通の dict は TypeDeserializer が
+                # TypeError 等を送出するため、意図的に再帰フォールバックする。
+                # ポリシー上、実データ値はログに出さない(キー名と例外型のみ)。
+                logger.debug(
+                    "deserialize: TypeDeserializer failed for key=%s (%s); falling back to plain-dict recursion",
+                    k,
+                    type(err).__name__,
+                )
                 result[k] = deserialize(v)
         else:
             result[k] = v

--- a/tests/test_dbfield.py
+++ b/tests/test_dbfield.py
@@ -99,6 +99,26 @@ class TestDBFieldValidation(unittest.TestCase):
             with self.assertRaises(ValidationError):
                 field.validate("not a collection")
 
+    def test_validation_error_message_hides_raw_value(self):
+        # 例外メッセージに実データ値 (PII の恐れ) を含めない。型・長さのみ。
+        field = DBField(type=FieldType.LIST)
+        field.name = "secret_field"
+        raw_value = "raw-secret-value"
+        with self.assertRaises(ValidationError) as ctx:
+            field.validate(raw_value)
+        message = str(ctx.exception)
+        self.assertNotIn(raw_value, message)
+        self.assertIn("secret_field", message)
+        self.assertIn("type=str", message)
+
+        field2 = DBField(type=FieldType.STRING)
+        field2.name = "secret_field2"
+        with self.assertRaises(ValidationError) as ctx:
+            field2.validate(["raw-secret-item"])
+        message = str(ctx.exception)
+        self.assertNotIn("raw-secret-item", message)
+        self.assertIn("type=list", message)
+
     def test_default_value_is_validated(self):
         # A default supplied when no value is given must still be type-validated.
         field = DBField(type=FieldType.NUMBER, default=5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,16 @@ from decimal import Decimal
 from boto3.dynamodb.conditions import Attr, Key
 
 from ddb_single.error import InvalidParameterError
-from ddb_single.utils_botos import QueryType, attr_ex, attr_method, is_same_json, json_export, json_import, range_ex
+from ddb_single.utils_botos import (
+    QueryType,
+    attr_ex,
+    attr_method,
+    deserialize,
+    is_same_json,
+    json_export,
+    json_import,
+    range_ex,
+)
 
 
 class TestUtilsBotos(unittest.TestCase):
@@ -80,6 +89,23 @@ class TestUtilsBotos(unittest.TestCase):
         data = {"key1": Decimal("1.23"), "key2": [Decimal("2.34"), Decimal("3.45")], "key3": {"key4": Decimal("4.56")}}
         expected = {"key1": 1.23, "key2": [2.34, 3.45], "key3": {"key4": 4.56}}
         self.assertEqual(json_export(data), expected)
+
+    def test_deserialize_typed_dict(self):
+        # DynamoDB 型付き dict はそのままデシリアライズされる
+        data = {"name": {"S": "hello"}, "count": {"N": "3"}}
+        self.assertEqual(deserialize(data), {"name": "hello", "count": Decimal("3")})
+
+    def test_deserialize_fallback_logs_debug(self):
+        # DynamoDB 型付きでない普通の dict は再帰フォールバックし、DEBUG ログが出る
+        data = {"outer": {"inner": {"S": "secret-value"}}}
+        with self.assertLogs("ddb_single.utils_botos", level="DEBUG") as cm:
+            result = deserialize(data)
+        self.assertEqual(result, {"outer": {"inner": "secret-value"}})
+        joined = "\n".join(cm.output)
+        self.assertIn("falling back", joined)
+        self.assertIn("key=outer", joined)
+        # 実データ値はログに出さない
+        self.assertNotIn("secret-value", joined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
ロギング・例外処理の衛生改善(2 Issue)。

- **#120**: `utils_botos.py` の `deserialize()` の `except Exception` を、boto3 `TypeDeserializer` が実際に投げる `(TypeError, AttributeError, KeyError)` に縮小。意図的な plain-dict 再帰フォールバックは維持しつつ、発火時に `logger.debug`(キー名と例外型のみ、値は出力しない)を追加。データ破損由来の例外(例: `decimal.InvalidOperation`)は握りつぶさず伝播
- **#119**: ログ・例外メッセージへの実データ値出力を廃止し、キー名・フィールド名・型・件数のみに統一
  - `table.py` `_execute_boto_op`: エラーログの `extra` から式の文字列化を除去し、有無のブール値に変更
  - `model.py` `_validate_value`: `ValidationError` メッセージから入力値を除去し、型名+長さのサマリに変更
  - `query.py` `get_by_unique` / `batch_get_by_unique`: DEBUG ログからユニークキー値・結果アイテムを除去

## 検証
- `uv run pytest -v`: 120 passed, 15 subtests passed(フォールバックログ・メッセージ非含有のテストを追加)
- `ruff check` / `ruff format --check` クリーン

Closes #119
Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ・プライバシー**
  * バリデーションエラーやログに、入力値・検索条件・検索結果などの実データを出力しないよう改善しました。
  * ログには型情報、件数、項目の有無などの安全な概要のみを記録します。

* **バグ修正**
  * DynamoDBデータの変換に失敗した場合、通常の辞書として再帰的に処理できるよう改善しました。

* **テスト**
  * 機密情報がエラーメッセージやデバッグログに含まれないことを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->