### PR TITLE
test: consolidate Table creation and dummy AWS credentials into conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Shared test helpers (issue #124).
+
+Centralizes the DynamoDB Local endpoint and the dummy AWS credentials used by
+the test suite so individual test modules never embed connection settings.
+Every value can be overridden through an environment variable, but the
+defaults always point at DynamoDB Local (never at real AWS).
+"""
+
+import datetime
+import os
+
+from ddb_single.table import Table
+
+TEST_ENDPOINT_URL = os.environ.get("DDB_TEST_ENDPOINT_URL", "http://localhost:8000")
+TEST_REGION_NAME = os.environ.get("DDB_TEST_REGION_NAME", "us-west-2")
+TEST_AWS_ACCESS_KEY_ID = os.environ.get("DDB_TEST_AWS_ACCESS_KEY_ID", "fakeMyKeyId")
+TEST_AWS_SECRET_ACCESS_KEY = os.environ.get("DDB_TEST_AWS_SECRET_ACCESS_KEY", "fakeSecretAccessKey")
+
+
+def make_table(name_prefix, timestamp=True, **kwargs):
+    """Build a ``Table`` bound to DynamoDB Local with dummy credentials.
+
+    ``name_prefix`` gets a timestamp suffix by default so each test
+    module/class works on its own independent table. Pass ``timestamp=False``
+    for tests that never call ``init()`` and just need a fixed name.
+    Extra keyword arguments are forwarded to ``Table``.
+    """
+    table_name = name_prefix
+    if timestamp:
+        table_name += datetime.datetime.now().strftime("%Y%m%d%H%M%S%f")
+    return Table(
+        table_name=table_name,
+        endpoint_url=TEST_ENDPOINT_URL,
+        region_name=TEST_REGION_NAME,
+        aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+        **kwargs,
+    )

--- a/tests/models_for_cli.py
+++ b/tests/models_for_cli.py
@@ -1,18 +1,11 @@
-import datetime
 import logging
 
 from ddb_single.model import BaseModel, DBField
-from ddb_single.table import Table
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="table_cli_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("table_cli_test_")
 table.init()
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,20 +1,14 @@
-import datetime
 import logging
 import unittest
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="batch_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("batch_test_")
 table.init()
 
 

--- a/tests/test_capacity_units.py
+++ b/tests/test_capacity_units.py
@@ -1,22 +1,13 @@
-import datetime
 import unittest
 
-from ddb_single.table import Table
+from tests.conftest import make_table
 
 
 class TestCapacityUnits(unittest.TestCase):
     def test_create_table_uses_write_capacity_for_writes(self):
         """create_table() must apply WriteCapacityUnits to the write throughput,
         not the read setting."""
-        table = Table(
-            table_name="capacity_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S%f"),
-            endpoint_url="http://localhost:8000",
-            region_name="us-west-2",
-            aws_access_key_id="fakeMyKeyId",
-            aws_secret_access_key="fakeSecretAccessKey",
-            ReadCapacityUnits=3,
-            WriteCapacityUnits=7,
-        )
+        table = make_table("capacity_test_", ReadCapacityUnits=3, WriteCapacityUnits=7)
         table.init()
         try:
             desc = table.__client__.describe_table(TableName=table.__table_name__)["Table"]

--- a/tests/test_desc.py
+++ b/tests/test_desc.py
@@ -1,20 +1,14 @@
-import datetime
 import logging
 import unittest
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="desc_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("desc_test_")
 table.init()
 
 

--- a/tests/test_duplicate_key_condition.py
+++ b/tests/test_duplicate_key_condition.py
@@ -5,24 +5,17 @@ Previously DynamoDB returned ValidationException; ddb_single now rejects these
 before the API call (GitHub issue #967).
 """
 
-import datetime
 import logging
 import unittest
 
 from boto3.dynamodb.conditions import Key
 
 from ddb_single.error import InvalidParameterError
-from ddb_single.table import Table
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.DEBUG)
 
-table = Table(
-    table_name="duplicate_key_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("duplicate_key_test_")
 
 
 class TestDuplicateKeyCondition(unittest.TestCase):

--- a/tests/test_key_condition_util.py
+++ b/tests/test_key_condition_util.py
@@ -10,7 +10,8 @@ from ddb_single.key_condition_util import (
     iter_key_attributes_used_in_key_condition,
     validate_single_condition_per_key,
 )
-from ddb_single.table import SearchExpression, Table, _coerce_search_expression_filter_status
+from ddb_single.table import SearchExpression, _coerce_search_expression_filter_status
+from tests.conftest import make_table
 
 
 class TestKeyConditionUtil(unittest.TestCase):
@@ -73,13 +74,7 @@ class TestKeyConditionUtil(unittest.TestCase):
 
     def test_search_simple_path_rejects_gsi_shape_on_search_status(self):
         """SEARCH expressions must only add primary-key predicates (issue #967 merge bug)."""
-        t = Table(
-            table_name="t",
-            endpoint_url="http://localhost:8000",
-            region_name="us-west-2",
-            aws_access_key_id="f",
-            aws_secret_access_key="f",
-        )
+        t = make_table("t", timestamp=False)
         bad = SearchExpression(
             FilterStatus=util_b.FilterStatus.SEARCH,
             KeyConditionExpression=Key("sk").eq("search_user_name") & Key("data").eq("v"),

--- a/tests/test_prefix_collision.py
+++ b/tests/test_prefix_collision.py
@@ -5,24 +5,19 @@ models where one model name is a prefix of another
 (e.g. "user" vs "user_admin", "note" vs "note_child").
 """
 
-import datetime
 import logging
 import unittest
 import uuid
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import Table
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name=f"prefix_col_{datetime.datetime.now():%Y%m%d%H%M%S%f}_{uuid.uuid4().hex}",
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+# uuid suffix in the prefix keeps uniqueness at least as strong as the
+# original timestamp+uuid name; make_table appends the timestamp itself.
+table = make_table(f"prefix_col_{uuid.uuid4().hex}_")
 table.init()
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import unittest
 from unittest.mock import MagicMock, patch
@@ -6,17 +5,12 @@ from unittest.mock import MagicMock, patch
 from ddb_single.error import ValidationError
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="query_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("query_test_")
 table.init()
 
 

--- a/tests/test_query_unique_doubled.py
+++ b/tests/test_query_unique_doubled.py
@@ -1,20 +1,13 @@
-import datetime
 import logging
 import unittest
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import Table
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.DEBUG)
 
-table = Table(
-    table_name="query_unique_doubled_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("query_unique_doubled_test_")
 table.init()
 
 

--- a/tests/test_query_unique_regression.py
+++ b/tests/test_query_unique_regression.py
@@ -1,17 +1,10 @@
-import datetime
 import unittest
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import Table
+from tests.conftest import make_table
 
-table = Table(
-    table_name="query_unique_regression_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("query_unique_regression_")
 table.init()
 
 

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -1,21 +1,15 @@
-import datetime
 import logging
 import unittest
 
 from ddb_single.error import NotFoundError
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="rel_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("rel_test_")
 table.init()
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,20 +1,14 @@
-import datetime
 import logging
 import unittest
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="search_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("search_test_")
 table.init()
 
 

--- a/tests/test_search_fallback_on_validation_exception.py
+++ b/tests/test_search_fallback_on_validation_exception.py
@@ -5,8 +5,8 @@ from botocore.exceptions import ClientError
 
 from ddb_single.error import InvalidParameterError
 from ddb_single.model import BaseModel, DBField
-from ddb_single.table import Table
 from ddb_single.utils_botos import FilterStatus
+from tests.conftest import make_table
 
 
 def _validation_exception(message: str) -> ClientError:
@@ -34,12 +34,7 @@ def _client_error(code: str, message: str) -> ClientError:
 
 
 class Rocket(BaseModel):
-    __table__ = Table(
-        table_name="dummy",
-        region_name="us-west-2",
-        aws_access_key_id="dummy",
-        aws_secret_access_key="dummy",
-    )
+    __table__ = make_table("dummy", timestamp=False)
     __model_name__ = "rocket"
     name = DBField(unique_key=True, ignore_case=True)
 

--- a/tests/test_search_index_update.py
+++ b/tests/test_search_index_update.py
@@ -1,19 +1,12 @@
-import datetime
 import unittest
 
 from boto3.dynamodb.conditions import Key
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import Table
+from tests.conftest import make_table
 
-table = Table(
-    table_name="search_update_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("search_update_")
 table.init()
 
 

--- a/tests/test_search_key_chunking.py
+++ b/tests/test_search_key_chunking.py
@@ -1,11 +1,11 @@
-import datetime
 import unittest
 
 from boto3.dynamodb.conditions import Key
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 
 class LongText(BaseModel):
@@ -18,13 +18,7 @@ class LongText(BaseModel):
 class TestSearchKeyChunking(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        table = Table(
-            table_name="chunk_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-            endpoint_url="http://localhost:8000",
-            region_name="us-west-2",
-            aws_access_key_id="fakeMyKeyId",
-            aws_secret_access_key="fakeSecretAccessKey",
-        )
+        table = make_table("chunk_test_")
         table.init()
         LongText.__table__ = table
         cls.table = table

--- a/tests/test_search_table.py
+++ b/tests/test_search_table.py
@@ -1,21 +1,15 @@
-import datetime
 import logging
 import unittest
 
 import ddb_single.utils_botos as util_b
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import Attr, FieldType, Key, SearchExpression, Table
+from ddb_single.table import Attr, FieldType, Key, SearchExpression
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="table_search_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("table_search_test_")
 table.init()
 
 

--- a/tests/test_set_types.py
+++ b/tests/test_set_types.py
@@ -6,24 +6,18 @@ types unusable. These tests verify that set-type fields validate element-wise
 and round-trip through DynamoDB Local.
 """
 
-import datetime
 import logging
 import unittest
 from decimal import Decimal
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
 
-table = Table(
-    table_name="set_types_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("set_types_test_")
 table.init()
 
 

--- a/tests/test_unique_search_validation_exception.py
+++ b/tests/test_unique_search_validation_exception.py
@@ -6,23 +6,17 @@ This test reproduces the issue where searching by unique key causes:
  KeyConditionExpressions must only contain one condition per key"
 """
 
-import datetime
 import logging
 import unittest
 
 from ddb_single.model import BaseModel, DBField
 from ddb_single.query import Query
-from ddb_single.table import FieldType, Table
+from ddb_single.table import FieldType
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.DEBUG)
 
-table = Table(
-    table_name="unique_search_test_" + datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
-    endpoint_url="http://localhost:8000",
-    region_name="us-west-2",
-    aws_access_key_id="fakeMyKeyId",
-    aws_secret_access_key="fakeSecretAccessKey",
-)
+table = make_table("unique_search_test_")
 table.init()
 
 

--- a/tests/test_validation_exception_handling.py
+++ b/tests/test_validation_exception_handling.py
@@ -3,26 +3,14 @@ Test that ValidationException is properly re-raised instead of being silently ca
 """
 
 import logging
-import time
 import unittest
 from unittest.mock import MagicMock
 
 from botocore.exceptions import ClientError
 
-from ddb_single.table import Table
+from tests.conftest import make_table
 
 logging.basicConfig(level=logging.INFO)
-
-
-def _make_table() -> Table:
-    """Build a Table with a unique name (never connects to DynamoDB in these tests)."""
-    return Table(
-        table_name=f"test_{time.time_ns()}",
-        endpoint_url="http://localhost:8000",
-        region_name="us-west-2",
-        aws_access_key_id="fakeMyKeyId",
-        aws_secret_access_key="fakeSecretAccessKey",
-    )
 
 
 class TestValidationExceptionHandling(unittest.TestCase):
@@ -34,7 +22,7 @@ class TestValidationExceptionHandling(unittest.TestCase):
         it is re-raised instead of being caught and returning empty list.
         """
         # Create a table without actually connecting to DynamoDB
-        table = _make_table()
+        table = make_table("test_")
 
         # Create a mock table
         mock_boto_table = MagicMock()
@@ -65,7 +53,7 @@ class TestValidationExceptionHandling(unittest.TestCase):
         With ``fail_on_second_page=True``, the first call returns a page with a
         ``LastEvaluatedKey`` and the error is raised on the pagination call.
         """
-        table = _make_table()
+        table = make_table("test_")
         mock_boto_table = MagicMock()
         error_response = {
             "Error": {"Code": error_code, "Message": error_message},
@@ -170,7 +158,7 @@ class TestValidationExceptionHandling(unittest.TestCase):
         Test that ValidationException in scan() is also re-raised.
         """
         # Create a table without actually connecting to DynamoDB
-        table = _make_table()
+        table = make_table("test_")
 
         # Create a mock table
         mock_boto_table = MagicMock()


### PR DESCRIPTION
## 概要
テスト全体に重複していた `Table(...)` 生成とダミー AWS 認証情報を `tests/conftest.py` の `make_table()` ヘルパーに集約(17 ファイルをリファクタ、+85/-167 行)。

- `endpoint_url`(デフォルト `http://localhost:8000`)・`region_name`・ダミー認証情報を一元化。環境変数(`DDB_TEST_ENDPOINT_URL` 等)で上書き可能
- モジュール import 時に `Table` を生成するテストが 12 ファイルあるため、fixture ではなく import 可能なヘルパー関数を採用
- タイムスタンプによるテーブル名の一意性は維持(モックのみのテストは `timestamp=False`)
- **セキュリティ修正**: `tests/test_search_fallback_on_validation_exception.py` で `endpoint_url` 未指定だった `Table` を DynamoDB Local に明示固定(モック漏れ時に実 AWS へ飛ぶ余地を排除)

## 検証
- `uv run pytest -v`: 117 passed, 15 subtests passed
- `ruff check` / `ruff format --check` クリーン

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * DynamoDB Local向けの接続設定とダミー認証情報を一元化しました。
  * テスト用テーブルを自動的に一意な名前で作成できる共通ヘルパーを追加しました。
  * 各テストのセットアップを共通化し、実行環境の設定変更やテスト間の干渉を抑制しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->