### PR TITLE
fix(security): bind compose ports to loopback and pin dynamodb-admin image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,13 @@ services:
     command: "-jar DynamoDBLocal.jar -sharedDb"
     image: "amazon/dynamodb-local:3.3.0"
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
   dynamodb-admin:
-    image: aaronshaf/dynamodb-admin
+    # Pinned by digest (tag 5.3.4) to avoid pulling mutable "latest"
+    image: aaronshaf/dynamodb-admin:5.3.4@sha256:ac41724cd99706256d405a14a5fb96f51f18c41a630c84fa3357f900cbd16d2e
     tty: true
     ports:
-      - "8001:8001"
+      - "127.0.0.1:8001:8001"
     depends_on:
       - dynamodb-local
     environment:


### PR DESCRIPTION
## 概要
docker-compose.yml のセキュリティ強化。

- ポート公開をループバック限定に変更: `"8000:8000"` → `"127.0.0.1:8000:8000"`(dynamodb-local)、`"8001:8001"` → `"127.0.0.1:8001:8001"`(dynamodb-admin)。認証なしの DynamoDB Local / 管理 UI が外部ホストから到達不能に
- `aaronshaf/dynamodb-admin`(暗黙の `latest`)を `5.3.4` のマルチアーチ manifest digest でピン留め(タグをコメントで併記)

## 検証
`docker compose config -q` 成功。

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr
