### PR TITLE
ci: harden GitHub Actions workflows (least privilege, SHA pinning)

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -53,7 +53,7 @@ jobs:
           uv run sphinx-build ./docs_src ./docs
 
       - name: Upload static files as artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./docs
 
@@ -64,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint_and_test
     permissions:
-      contents: write
+      contents: read
       id-token: write
       pages: write
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,21 +19,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    permissions:
+      # Push the release tag (via credentials persisted by actions/checkout)
+      contents: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
       - name: Get changelog
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           dry_run: true
@@ -58,7 +59,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-      - uses: peter-evans/create-pull-request@v8
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "[skip ci] Bump version to ${{ env.VERSION }}"
           delete-branch: true
@@ -70,12 +71,14 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Create and push tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git tag v${{ env.VERSION }}
           git push origin v${{ env.VERSION }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ env.VERSION }}
           name: Release v${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      # Push the release tag (via credentials persisted by actions/checkout)
+      # Read tags for the changelog and create the GitHub Release (built-in GITHUB_TOKEN)
       contents: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Do not persist credentials; the tag push authenticates explicitly with GH_TOKEN
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -36,7 +39,8 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          # Dry run only computes the changelog; the built-in token is sufficient
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: true
 
       - name: Update version
@@ -72,10 +76,10 @@ jobs:
 
       - name: Create and push tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          git tag v${{ env.VERSION }}
-          git push origin v${{ env.VERSION }}
+          git tag "v${VERSION}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "v${VERSION}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -85,4 +89,5 @@ jobs:
           draft: false
           prerelease: false
           body: ${{ steps.tag_version.outputs.changelog }}
-          token: ${{ secrets.GH_TOKEN }}
+          # Release creation only needs contents: write; use the built-in token
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
GitHub Actions ワークフローのセキュリティ強化(#113 の OIDC 移行は別 PR に分離)。

- **#110**: release.yml のジョブレベル `GH_TOKEN` env を削除し、PAT を「Create and push tag」ステップのみのステップレベル env に縮小(他のステップは `with: token:` で受け取り済み)
- **#111**: release.yml の build ジョブに明示的な最小権限 `permissions:` ブロックを追加(`contents: write` のみ)
- **#112**: 両ワークフローの全アクションをフルコミット SHA でピン留め(`# vX.Y.Z` コメント付き、Dependabot 追従あり)
- **#114**: lint_and_test.yml の deploy ジョブの `contents: write` を `read` に縮小(`actions/deploy-pages` は `pages: write` + `id-token: write` のみ必要)

## 検証
- 両ワークフローファイルが pyyaml でパース成功
- SHA は `gh api` でタグから解決(annotated tag はデリファレンス済み)

Closes #110
Closes #111
Closes #112
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 開発・リリース自動化で使用する外部アクションの参照を固定し、実行環境の安定性と安全性を向上しました。
  - リリース処理の権限設定を明確化し、タグ作成やリリース公開をより確実に実行できるよう改善しました。
  - 既存の lint、テスト、ビルド、ドキュメント生成などの処理内容に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->