### PR TITLE
[DO NOT MERGE] ci: migrate PyPI publishing to Trusted Publisher (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     permissions:
       # Read tags for the changelog and create the GitHub Release (built-in GITHUB_TOKEN)
       contents: write
+      # PyPI Trusted Publishing (OIDC)
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -52,11 +54,9 @@ jobs:
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Build and publish package
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           uv build
-          uv publish
+          uv publish --trusted-publishing always
 
       - name: Set up git
         run: |


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — PyPI 側の設定完了まで draft のままにしてください

PyPI 公開を Trusted Publisher (OIDC) へ移行し、長期トークンを廃止します。

- `uv publish --trusted-publishing always` による OIDC 公開に変更し、`UV_PUBLISH_TOKEN` / `PYPI_API_TOKEN` の使用を削除
- build ジョブに `id-token: write` を追加

## マージ前に必要な手動作業(メンテナ)
1. pypi.org の `ddb-single` プロジェクトで Trusted Publisher を登録
   - Owner: `medaka0213` / Repository: `DynamoDB-SingleTable` / Workflow: `release.yml` / Environment: なし
2. 登録後にこの PR をマージ
3. 旧 `PYPI_API_TOKEN` を破棄し、リポジトリシークレットから削除

登録前にマージすると次回リリースの publish ステップが失敗します。

Base ブランチは #110–#112, #114 の PR(`security/github-actions`)です。そちらがマージされると自動的に master 向けにリターゲットされます。

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap2iiT35hDsNTfQm1xA8Qr
