### PR TITLE
fix(ci): drop the GH_TOKEN PAT from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      # Read tags for the changelog and create the GitHub Release (built-in GITHUB_TOKEN)
+      # Read tags for the changelog, push the tag, create the GitHub Release
       contents: write
+      # Open the version-bump pull request
+      pull-requests: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Do not persist credentials; the tag push authenticates explicitly with GH_TOKEN
+          # Do not persist credentials; the tag push authenticates explicitly,
+          # and create-pull-request configures its own credential from `token`
           persist-credentials: false
 
       - name: Install uv
@@ -72,11 +75,13 @@ jobs:
           body: |
             Bump version to ${{ env.VERSION }}
             ${{ steps.tag_version.outputs.changelog }}
-          token: ${{ secrets.GH_TOKEN }}
+          # The bump commit carries [skip ci] and lint_and_test.yml has no
+          # pull_request trigger, so nothing is lost by using the built-in token.
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push tag
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git tag "v${VERSION}"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "v${VERSION}"


### PR DESCRIPTION
## Problem

The 0.6.2 release ([run 29846413214](https://github.com/medaka0213/DynamoDB-SingleTable/actions/runs/29846413214)) failed at `create-pull-request`:

```
git -c protocol.version=2 fetch ... origin release/0.6.2
fatal: could not read Username for 'https://github.com': No such device or address
```

`create-pull-request` configures its own `http.<host>/.extraheader` credential from the `token` input ([`git-config-helper.ts#L144`](https://github.com/peter-evans/create-pull-request/blob/5f6978faf089d4d20b00c7766989d076bb2fc7f1/src/git-config-helper.ts#L144)), so `persist-credentials: false` was not the cause. The action also errors out early when `token` is empty, so the secret was set — GitHub simply rejected it, and git fell back to an interactive prompt. The `GH_TOKEN` PAT is expired or revoked.

`uv publish` runs before this step, so **0.6.2 is already on PyPI** while the version bump, tag, and release were never created. That cleanup is tracked separately.

## Why the PAT is unnecessary

It existed so the version-bump PR would trigger CI, since pushes made with `GITHUB_TOKEN` do not start workflow runs. That rationale does not hold here:

- `lint_and_test.yml` triggers on `push` only — there is no `pull_request` trigger, so the PR itself never started a run.
- The bump commit message carries `[skip ci]`, so the branch push was skipped regardless of which token created it.
- `master`'s branch protection requires no status checks (`required_status_checks.contexts` is empty).
- No workflow is meant to run on tag pushes.
- "Allow GitHub Actions to create and approve pull requests" is enabled, so `GITHUB_TOKEN` can open the PR.

The PAT bought nothing and added a credential that silently expires.

## Changes

- `create-pull-request` and the tag push now use `secrets.GITHUB_TOKEN`
- Added `pull-requests: write`, which the built-in token needs to open the PR
- Updated two now-stale comments

`secrets.GH_TOKEN` is no longer referenced by any workflow and can be deleted.

## Follow-ups (not in this PR)

- `uv publish` still runs before the git steps, so a git-side failure leaves PyPI ahead with no way back — exactly what happened here. Moving it after tag creation and adding `--check-url` would make re-runs idempotent.
- If the bump PR should run CI in future, add a `pull_request:` trigger to `lint_and_test.yml` rather than reintroducing a PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5iu433SYDfNXF76rwrMrr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * リリースワークフローの権限設定と認証トークンを見直し、バージョン更新用プルリクエストの作成やタグ操作が適切に実行されるよう改善しました。
  * リリース時のコメントと設定内容を実際の処理に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->