### PR TITLE
fix(ci): publish to PyPI after the git steps, and make re-runs idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,11 @@ jobs:
           version=$(uv version --short)
           echo "VERSION=$version" >> $GITHUB_ENV
 
-      - name: Build and publish package
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          uv build
-          uv publish
+      # Build before touching git so a broken build fails the run cheaply.
+      # dist/ is gitignored, so it survives the working-tree resets that
+      # create-pull-request performs and is still present at publish time.
+      - name: Build package
+        run: uv build
 
       - name: Set up git
         run: |
@@ -85,6 +84,14 @@ jobs:
         run: |
           git tag "v${VERSION}"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "v${VERSION}"
+
+      # Published last: PyPI uploads cannot be undone, so everything that can
+      # still fail runs first. --check-url skips files already on the index
+      # instead of failing with "400 File already exists", making re-runs safe.
+      - name: Publish package to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish --check-url https://pypi.org/simple/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2


### PR DESCRIPTION
## Problem

The 0.6.2 release wedged itself across two runs.

[Run 29846413214](https://github.com/medaka0213/DynamoDB-SingleTable/actions/runs/29846413214) published `ddb_single 0.6.2` to PyPI, then failed at `create-pull-request` on the expired PAT (fixed in #141). PyPI was now ahead of the repository, and that cannot be rolled back — PyPI does not allow filename reuse.

[Run 29847283669](https://github.com/medaka0213/DynamoDB-SingleTable/actions/runs/29847283669) then failed even earlier:

```
error: Failed to publish `dist/ddb_single-0.6.2.tar.gz`
  Caused by: 400 File already exists ('ddb_single-0.6.2.tar.gz', ...)
```

`master` was still at `0.6.1`, so `--bump patch` produced `0.6.2` again, which PyPI already had. No number of re-runs could get past that step.

## Changes

**Publish last.** `uv build` still runs early so a broken build fails the run cheaply, but the upload now happens after the PR and the tag exist:

```
build → set up git → create PR → push tag → publish → release
```

The PyPI upload is the only irreversible step in the workflow, so everything that can still fail now runs before it. Had this ordering been in place, the first run would have failed with nothing published and a plain re-run would have succeeded.

`dist/` is gitignored, so the artifacts survive the working-tree resets `create-pull-request` performs (`git reset --hard origin/master`, branch switches) and are still present at publish time.

**`uv publish --check-url https://pypi.org/simple/`.** Files already present on the index are skipped rather than rejected, so a re-run after a partial failure no longer dies on `400 File already exists`.

## Not addressed here

`master` is still at `0.6.1` while PyPI has `0.6.2`, and there is no `v0.6.2` tag or release. That state predates this PR and is reconciled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5iu433SYDfNXF76rwrMrr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリース時のビルドとパッケージ公開の処理を分離しました。
  * パッケージ公開処理を明示的に実行する構成に変更しました。
  * 既に公開済みのファイルがある場合でも、リリース処理を安全に再実行できるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->